### PR TITLE
adding a 'legend' to the vdiagram report

### DIFF
--- a/inst/vdiagram/vdiagram.Rmd
+++ b/inst/vdiagram/vdiagram.Rmd
@@ -11,3 +11,5 @@ vdiagram(data)
 ```{r,echo=FALSE}
 vdiagramTable(data, output)
 ```
+Horizontal red bars at max and min gage height for the period shown.   
+Unlabeled blue points are historical measurements from the last 2 years.  


### PR DESCRIPTION
One thing I'm not sure about, is how to make sure the report stays on two pages. should I alter the margins in the yaml? Suggestions?

right now it pushes the heading/title onto a new page for the 2nd report, and then there is a page break before the rest of the report.

https://internal.cida.usgs.gov/jira/browse/AQCU-307
