### PR TITLE
Extremes mutate_ bug fix

### DIFF
--- a/R/extremes-data.R
+++ b/R/extremes-data.R
@@ -157,7 +157,12 @@ applyQualifiers <- function(data) {
 }
 
 applyQualifiersToValues <- function(points, qualifiers) {
-  if(is.null(points)) return(points)
+  if(identical("",points)){
+    points <- NULL
+  }
+  if(is.null(points)) {
+    return(points)
+  }
   
   getQualifierString <- function(p) {
     builtQualifiers <- ""


### PR DESCRIPTION
JSON was coming through with the empty string in mutate which was causing an error. By checking for 
"" and changing to null, extremes report is back to normal.
