### PR TITLE
sensorreading: logical statement should have && not ||

### DIFF
--- a/R/sensorreading-data.R
+++ b/R/sensorreading-data.R
@@ -67,7 +67,7 @@ formatSensorData <- function(data, columnNames){
     }
     #Get the time out of the nearest corrected iv time, don't need the date
     if ("nearestcorrectedTime" %in% names(data)) {
-      if (!is.null(listElements$nearestcorrectedTime) || !is.na(listElements$nearestcorrectedTime)) {
+      if (!is.null(listElements$nearestcorrectedTime) && !is.na(listElements$nearestcorrectedTime)) {
         dateTimeCorrected <- (strsplit(listElements$nearestcorrectedTime, split="[T]"))
         dateCorrected <- strftime(dateTimeCorrected[[1]][1], "%m/%d/%Y")
         


### PR DESCRIPTION
@thongsav-usgs found error with a sensor reading report (https://cida-eros-aqcudev.er.usgs.gov:8443/aqcu-front-end/service/reports/sensorreadingsummary/?primaryTimeseriesIdentifier=c15d549506074110adbe04f1cf0e31f2&station=01047200&waterYear=2014). 

In sensorreading-data, there was a logical statement to bypass code by checking for NULL and NA values. The if statement using "or" instead of "and" so, if data was NA, it made it through to the code (b/c NA is not NULL). Now, NULL and NA data will cause it to bypass this section.
