### PR TITLE
truncating labels for uvhydro & vdiagram round 2

### DIFF
--- a/R/utils-shared.R
+++ b/R/utils-shared.R
@@ -79,7 +79,7 @@ testCallouts <- function(plot_obj, xlimits){
   
   png('TMP_PLOT')
   print(plot_obj)
-  width_char <- par("cxy")[1]*xrange
+  width_char <- par("cxy")[1]
   #When you're done
   dev.off()
   #Delete the plot you just generated
@@ -88,7 +88,7 @@ testCallouts <- function(plot_obj, xlimits){
   i_view12 <- which(names(plot_obj$view.1.2) == "callouts")
   i_view14 <- which(names(plot_obj$view.1.4) == "callouts")
   
-  testCalloutsByView <- function(plot_obj, callouts_index, view_num, xlimits_real, width_char){
+  testCalloutsByView <- function(plot_obj, callouts_index, view_num, xlimits_real, width_char, xrange){
     for(i in callouts_index){
       callout_args <- plot_obj[[view_num]][[i]]
       text_len <- nchar(callout_args$labels)
@@ -109,8 +109,8 @@ testCallouts <- function(plot_obj, xlimits){
     return(plot_obj)
   }
   
-  plot_obj <- testCalloutsByView(plot_obj, i_view12, 'view.1.2', xlimits_real, width_char)
-  plot_obj <- testCalloutsByView(plot_obj, i_view14, 'view.1.4', xlimits_real, width_char)
+  plot_obj <- testCalloutsByView(plot_obj, i_view12, 'view.1.2', xlimits_real, width_char, xrange)
+  plot_obj <- testCalloutsByView(plot_obj, i_view14, 'view.1.4', xlimits_real, width_char, xrange)
   
   return(plot_obj)
 }


### PR DESCRIPTION
updated how `width_char` is calculated. Example illustrating truncated labels from @thongsav-usgs  was because it thought that the label was getting cutoff on the right axis b/c the character width used was enormous, so it rotated the callout. Since it was near the left axis, it was truncated from the left. 

Example from PT: https://cida-eros-aqcudev.er.usgs.gov:8443/aqcu-front-end/service/reports/vdiagram/?primaryTimeseriesIdentifier=209c5e8130244dcc995a0b1321cd74eb&upchainTimeseriesIdentifier=925c02693cc247b4a00ac0d605ce4fc0&ratingModelIdentifier=Gage+height-Discharge.STGQ%4006934500&station=06934500&lastMonths=12
