### PR TITLE
Edits to Extremes Report so that the report removes duplicate max/mins 

### DIFF
--- a/R/extremes-data.R
+++ b/R/extremes-data.R
@@ -118,7 +118,11 @@ extremesTable <- function(rawData){
 
     toRet <- rbind(toRet,toAdd)
   }
-  
+  #Get rid of duplicates for same date, time, primary and upchain params
+  #Hack because we can't use the duplicated function on columns with the same name
+  colnames(toRet) <- c("","Date","Time","Test","Test2") 
+  toRet <- toRet[!duplicated(toRet[,c("Date","Test","Test2")]),]
+  colnames(toRet) <- columnNames
   return(toRet)
 }
 

--- a/inst/extremes/extremes.Rmd
+++ b/inst/extremes/extremes.Rmd
@@ -26,5 +26,5 @@ cat(getLogo())
 tbl <- extremesTable(data)
 # formTable <- padTable(tbl)
 # cat(formTable)
-kable(tbl, align='r')
+kable(tbl, align='r', row.names=FALSE)
 ```


### PR DESCRIPTION
If they are the same value. Keeps only the first record regardless of time.

https://internal.cida.usgs.gov/jira/browse/AQCU-605

@lindsaycarr can you check this out? Original and new examples attached to the JIRA ticket. 

I did a hacky fix on the column names because in the example I was working with at least, the column names need to be used in the !duplicated function, and in the example (see the attached json) two of the column names are the same and it hates that. So, I change the names temporarily, do the !duplicated call and then change them back to the originals.. 
