### PR TITLE
Fix for AQCU-639

### DIFF
--- a/R/extremes-data.R
+++ b/R/extremes-data.R
@@ -24,8 +24,8 @@ extremesTable <- function(rawData){
   columnNames <- c("",
                    "Date", 
                    "Time", 
-                   paste(primaryParameter, " (", primaryUnit, ")"), 
-                   paste(upchainParameter, " (", upchainUnit, ")")
+                   paste("Primary series </br>", primaryParameter, "</br> (", primaryUnit, ")"), 
+                   paste("Upchain series </br>", upchainParameter, "</br> (", upchainUnit, ")")
                    )
   
   orderedRowNames <- c(paste("Max Inst ", upchainParameter, " and corresponding ", primaryParameter), 
@@ -118,8 +118,8 @@ extremesTable <- function(rawData){
     rownames(toAdd) <- NULL
     if (nrow(toAdd)>1) {
       temp <- toAdd
-      upchain <- paste(upchainParameter, " (", upchainUnit, ")")
-      primary <- paste(primaryParameter, " (", primaryUnit, ")")
+      upchain <- paste("Upchain series ", upchainParameter, " (", upchainUnit, ")")
+      primary <- paste("Primary series ", primaryParameter, " (", primaryUnit, ")")
       colnames(temp) <- c("Temp", "Date", "Time", primary, upchain)
       colnames(toAdd) <- c("Temp", "Date", "Time", primary, upchain)
       if (grepl("Min", orderedRowNames[i])) {

--- a/R/utils-shared.R
+++ b/R/utils-shared.R
@@ -191,7 +191,7 @@ testCallouts <- function(plot_obj, xlimits){
   testCalloutsByView <- function(plot_obj, callouts_index, view_num, xlimits_real, width_char, xrange){
     for(i in callouts_index){
         callout_args <- plot_obj[[view_num]][[i]]
-        if (!is.na(callout_args$x[i] | !is.na(callout_args$y[i]))) {  
+        if (!is.na(xtfrm(callout_args$x[i]) | !is.na(xtfrm(callout_args$y[i])))) {  
           text_len <- nchar(callout_args$labels)
             
             len <- ifelse(is.null(callout_args$length), 0.1, callout_args$length)

--- a/R/utils-shared.R
+++ b/R/utils-shared.R
@@ -190,21 +190,23 @@ testCallouts <- function(plot_obj, xlimits){
   
   testCalloutsByView <- function(plot_obj, callouts_index, view_num, xlimits_real, width_char, xrange){
     for(i in callouts_index){
-      callout_args <- plot_obj[[view_num]][[i]]
-      text_len <- nchar(callout_args$labels)
-      
-      len <- ifelse(is.null(callout_args$length), 0.1, callout_args$length)
-      
-      xend <- len * xrange * cos(2*pi*(30/360))
-      xnew <- callout_args$x + xend + (width_char * text_len) 
-      tooLong <- xnew > xlimits_real[2]
-      
-      if(any(tooLong)){
-        out <- which(tooLong)
-        notout <- which(!tooLong)
-        plot_obj[[view_num]][[i]]$angle[notout] <- NA
-        plot_obj[[view_num]][[i]]$angle[out] <- 150
-      }
+        callout_args <- plot_obj[[view_num]][[i]]
+        if (!is.na(callout_args$x[i] | !is.na(callout_args$y[i]))) {  
+          text_len <- nchar(callout_args$labels)
+            
+            len <- ifelse(is.null(callout_args$length), 0.1, callout_args$length)
+            
+            xend <- len * xrange * cos(2*pi*(30/360))
+            xnew <- callout_args$x + xend + (width_char * text_len) 
+            tooLong <- xnew > xlimits_real[2]
+            
+            if(any(tooLong)){
+              out <- which(tooLong)
+              notout <- which(!tooLong)
+              plot_obj[[view_num]][[i]]$angle[notout] <- NA
+              plot_obj[[view_num]][[i]]$angle[out] <- 150
+            }
+        }
     }
     return(plot_obj)
   }


### PR DESCRIPTION
Was getting an error in vDiagram, running into cases where value of a callout x variable was NA, and the math couldn't be done correctly to test the callout length/angle. So, check to see first if the variable is NA instead of numeric value desired, and skip that test if so.
https://internal.cida.usgs.gov/jira/browse/AQCU-639
