### PR TITLE
Per https://internal.cida.usgs.gov/jira/browse/AQCU-670

### DIFF
--- a/R/dvhydrograph-render.R
+++ b/R/dvhydrograph-render.R
@@ -20,8 +20,8 @@ createDvhydrographPlot <- function(data){
   
   if(anyDataExist(dvData)){
     dvInfo <- parseDVSupplemental(data, dvData)
-    startDate <- formatDates(data$reportMetadata$startDate)
-    endDate <- formatDates(data$reportMetadata$endDate)
+    startDate <- formatDates(data$reportMetadata$startDate) 
+    endDate <- formatDates(data$reportMetadata$endDate) + hours(23) + minutes(45)
     plotDates <- seq(startDate, endDate, by=7*24*60*60)
     
     plot_object <- gsplot(ylog=dvInfo$logAxis, yaxs='r') %>% 
@@ -70,7 +70,7 @@ createRefPlot <- function(data, series) {
     logAxis <- isLogged(data, refData, ref_name)
     
     startDate <- formatDates(data$reportMetadata$startDate)
-    endDate <- formatDates(data$reportMetadata$endDate)
+    endDate <- formatDates(data$reportMetadata$endDate) + hours(23) + minutes(45)
     plotDates <- seq(startDate, endDate, by=7*24*60*60)
     
     plot_object <- gsplot(ylog=logAxis, yaxs='r') %>%

--- a/R/fiveyeargwsum-data.R
+++ b/R/fiveyeargwsum-data.R
@@ -40,7 +40,7 @@ parseFiveYrSupplemental <- function(data, parsedData){
   horizontalGrid <- signif(seq(from=seq_horizGrid[1], to=seq_horizGrid[2], along.with=seq_horizGrid), 1)
   
   startDate <- formatDates(data$reportMetadata$startDate, "fiveyr", "start")
-  endDate <- formatDates(data$reportMetadata$endDate, "fiveyr", "end") + hours(23) + minutes(45)
+  endDate <- formatDates(data$reportMetadata$endDate, "fiveyr", "end")
   
   date_seq_mo <- seq(from=startDate, to=endDate, by="month")
   first_yr <- date_seq_mo[which(month(date_seq_mo) == 1)[1]]

--- a/R/fiveyeargwsum-data.R
+++ b/R/fiveyeargwsum-data.R
@@ -40,7 +40,7 @@ parseFiveYrSupplemental <- function(data, parsedData){
   horizontalGrid <- signif(seq(from=seq_horizGrid[1], to=seq_horizGrid[2], along.with=seq_horizGrid), 1)
   
   startDate <- formatDates(data$reportMetadata$startDate, "fiveyr", "start")
-  endDate <- formatDates(data$reportMetadata$endDate, "fiveyr", "end")
+  endDate <- formatDates(data$reportMetadata$endDate, "fiveyr", "end") + hours(23) + minutes(45)
   
   date_seq_mo <- seq(from=startDate, to=endDate, by="month")
   first_yr <- date_seq_mo[which(month(date_seq_mo) == 1)[1]]

--- a/R/sig-dvhydrograph.R
+++ b/R/sig-dvhydrograph.R
@@ -7,6 +7,7 @@
 #'@examples
 #'library(gsplot)
 #'library(jsonlite)
+#'library(lubridate)
 #'data <- fromJSON(system.file('extdata','dvhydro-example.json', package = 'repgen'))
 #'dvhydrograph(data, 'html', 'Author Name')
 #'\dontrun{

--- a/man/dvhydrograph.Rd
+++ b/man/dvhydrograph.Rd
@@ -26,6 +26,7 @@ dvhydrograph(data, output, ...)
 \examples{
 library(gsplot)
 library(jsonlite)
+library(lubridate)
 data <- fromJSON(system.file('extdata','dvhydro-example.json', package = 'repgen'))
 dvhydrograph(data, 'html', 'Author Name')
 \dontrun{

--- a/tests/testthat/test-eg.R
+++ b/tests/testthat/test-eg.R
@@ -50,6 +50,7 @@ context("testing dvhydrograph")
 test_that("dvhydrograph examples work",{
   library(jsonlite)
   library(gsplot)
+  library(lubridate)
   data <- fromJSON(system.file('extdata','dvhydro-example.json', package = 'repgen'))
   expect_is(dvhydrograph(data,'html', 'Author Name'), 'character')
 })
@@ -57,6 +58,7 @@ test_that("dvhydrograph examples work",{
 test_that("dvhydrograph axes flip",{
   library(jsonlite)
   library(gsplot)
+  library(lubridate)
   data <- fromJSON(system.file('extdata','dvhydro-waterlevel-example.json', package = 'repgen'))
   expect_true(data$reportMetadata$isInverted)
   


### PR DESCRIPTION
This adds time to the last date in endDate to rectify the missing days bugs in dvhydro and fiveyeargwsum

Not sure if it is necessary in these reports, because the time window is so large, it may be hard to notice
