### PR TITLE
fixes for AQCU-663

### DIFF
--- a/R/correctionsataglance-data.R
+++ b/R/correctionsataglance-data.R
@@ -101,7 +101,7 @@ formatDateRange <- function(startD, endD){
   startSpan <- as.numeric(endSeq[1] - startSeq[1])
   endSpan <- as.numeric(tail(endSeq, 1) - tail(startSeq, 1))
   if(startSpan <= 16){dateSeq[1] <- NA}
-  if(endSpan <= 16){dateSeq[length(dateSeq)] <- NA}
+  if(endSpan <= 14){dateSeq[length(dateSeq)] <- NA}
   
   return(list(dateRange = c(startD, endD),
               dateSeq = dateSeq,

--- a/R/correctionsataglance-data.R
+++ b/R/correctionsataglance-data.R
@@ -85,7 +85,12 @@ formatDateRange <- function(startD, endD){
     startSeq <- seq(startD, endD, by="1 month")
   } else {
     fromDate <- as.POSIXct(format(seq(startD, length=2, by="month")[2], "%Y-%m-01"))
-    startSeq <- seq(fromDate, endD, by="1 month")
+    numdays <- as.numeric(difftime(strptime(endD, format="%Y-%m-%d"), strptime(startD,format="%Y-%m-%d"), units="days"))
+    if (numdays<=27) {
+      startSeq <- seq(fromDate, endD, by="-1 month")
+    } else {
+      startSeq <- seq(fromDate, endD, by="1 month")
+    }
     startSeq <- c(startD, startSeq)
   }
 


### PR DESCRIPTION
https://internal.cida.usgs.gov/jira/browse/AQCU-663

Months are not always labelled if report period does not span a full month.
https://cida-eros-aqcudev.er.usgs.gov:8443/aqcu-front-end/service/reports/correctionsataglance/?primaryTimeseriesIdentifier=7e08a86850aa46c4a6b78b3d7d271fb1&station=01047200&startDate=2013-01-15&endDate=2013-02-15

Approval period is not showing if report period is short.
https://cida-eros-aqcudev.er.usgs.gov:8443/aqcu-front-end/service/reports/correctionsataglance/?primaryTimeseriesIdentifier=7e08a86850aa46c4a6b78b3d7d271fb1&station=01047200&startDate=2013-03-01&endDate=2013-03-30

Sometimes get an error and report will not generate if report period is short.
https://cida-eros-aqcudev.er.usgs.gov:8443/aqcu-front-end/service/reports/correctionsataglance/?primaryTimeseriesIdentifier=7e08a86850aa46c4a6b78b3d7d271fb1&station=01047200&startDate=2012-12-15&endDate=2012-12-31
