### PR TITLE
Allow report to render for Aquarius-only training sites by removing

### DIFF
--- a/R/extremes-data.R
+++ b/R/extremes-data.R
@@ -7,6 +7,8 @@
 extremesTable <- function(rawData){
   
   data <- applyQualifiers(rawData)
+  l_qual <- data$dv$qualifiers
+  if (length(l_qual)==0) return ("The dataset requested is empty.")
   
   primaryLabel <- getReportMetadata(rawData,'primaryLabel')
   primaryParameter <- getReportMetadata(rawData,'primaryParameter')

--- a/inst/extremes/extremes.Rmd
+++ b/inst/extremes/extremes.Rmd
@@ -26,5 +26,8 @@ cat(getLogo())
 tbl <- extremesTable(data)
 # formTable <- padTable(tbl)
 # cat(formTable)
-kable(tbl, align='r', row.names=FALSE)
+if(!identical(tbl, "The dataset requested is empty.")){
+  kable(tbl, align='r', row.names=FALSE)
+}
 ```
+#`r if(identical(tbl, "The dataset requested is empty.")) {paste(tbl)}`#

--- a/inst/sensorreading/sensorreading.Rmd
+++ b/inst/sensorreading/sensorreading.Rmd
@@ -16,7 +16,7 @@ cat(getLogo())
 
 **`r getReportMetadata(data,'title',required=TRUE)` Report**
 
-**Location:**  `r getReportMetadata(data,'stationId',required=TRUE)` `r getReportMetadata(data,'stationName',required=TRUE)`
+**Location:**  `r getReportMetadata(data,'stationId', required=TRUE)` `r getReportMetadata(data,'stationName')`
 
 **Period:** `r getReportMetadata(data, 'startDate')` to `r getReportMetadata(data, 'endDate')`
 

--- a/inst/sitevisitpeak/sitevisitpeak.Rmd
+++ b/inst/sitevisitpeak/sitevisitpeak.Rmd
@@ -13,7 +13,7 @@ cat(getLogo())
 
 **`r getReportMetadata(data,'title',required=TRUE)` Report**
 
-**Location:**  `r getReportMetadata(data,'stationId',required=TRUE)` `r getReportMetadata(data,'stationName',required=TRUE)`
+**Location:**  `r getReportMetadata(data,'stationId',required=TRUE)` `r getReportMetadata(data,'stationName')`
 
 **Period:** `r getReportMetadata(data, 'startDate')` to `r getReportMetadata(data, 'endDate')`
 


### PR DESCRIPTION
requirement that stationName be present in json.
