### PR TITLE
removing the # signs here, shouldn't be necessary, printing out weird…

### DIFF
--- a/inst/extremes/extremes.Rmd
+++ b/inst/extremes/extremes.Rmd
@@ -30,4 +30,4 @@ if(!identical(tbl, "The dataset requested is empty.")){
   kable(tbl, align='r', row.names=FALSE)
 }
 ```
-#`r if(identical(tbl, "The dataset requested is empty.")) {paste(tbl)}`#
+`r if(identical(tbl, "The dataset requested is empty.")) {paste(tbl)}`


### PR DESCRIPTION
… ## at the bottom of report in the table

@kmschoep-usgs don't think we need those # symbols in there, they were causing the pound signs to print on the bottom of the table, like the r if statements above, just need to be wrapped in tick marks instead. double pound at the beginning is actually R Markdown syntax for header 2 (syntax to format text) which you effectively get if the command is true. But if it's not true, we see two # signs in the last row of the table that prints out.  
