### PR TITLE
Change in Approval Description would cause approval not to show

### DIFF
--- a/R/correctionsataglance-data.R
+++ b/R/correctionsataglance-data.R
@@ -138,9 +138,9 @@ formatDataList <- function(dataIn, type, ...){
                    dataNum = length(dataIn[[start]][i]))
   
   if(type == 'APPROVALS'){
-    approvalInfo <- getApprovalColors(dataIn$description)
-    extraData <- list(apprCol = approvalInfo$color,
-                      apprType = paste("Approval:", approvalInfo$type),
+    approvalColors <- getApprovalColors(dataIn$level)
+    extraData <- list(apprCol = approvalColors,
+                      apprType = paste("Approval:", dataIn$description),
                       apprDates = args$datesRange)
   } else if(type == 'META') {
     extraData <- list(metaLabel = dataIn[[args$annotation]][i])
@@ -186,13 +186,15 @@ formatThresholdsData <- function(thresholds){
   return(threshold_data)  
 }
 
-getApprovalColors <- function(approvals){
-  approvalType <- c("Working", "In-review", "Approved")
-  approvalColors <- c("red", "yellow", "green")
-  matchApproval <- match(approvals, approvalType)
-  rect_type <- approvalType[matchApproval]
-  rect_colors <- approvalColors[matchApproval]
-  return(list(color = rect_colors, type = rect_type))
+# Returns just the colors, in order, for a list of approval levels
+# Known Approval Levels:
+# 0=Working, 1=In Review, 2=Approved  Anything else is colored as 'grey'
+getApprovalColors <- function(approvalLevels){
+  knownApprovalLevels <- c(0, 1, 2)
+  approvalColors <- c("red", "yellow", "green", "grey") #R, Y & G are colors for known approvals.  Grey only used for possible unknown values.
+  matchApproval <- match(approvalLevels, knownApprovalLevels, 4) #Defaults to 4 which corresponds to grey for an unrecognized type
+  colors <- approvalColors[matchApproval]
+  return(colors)
 }
 
 findOverlap <- function(dataList){

--- a/inst/extdata/correctionsataglance/correctionsataglance-example5.json
+++ b/inst/extdata/correctionsataglance/correctionsataglance-example5.json
@@ -1,0 +1,259 @@
+{
+  "thresholds": [],
+  "primarySeries": {
+    "requestedStartTime": "2015-04-01T00:00:00.000-06:00",
+    "requestedEndTime": "2016-04-11T00:00:00.000-06:00",
+    "notes": [
+      {
+        "startDate": "2015-07-09T09:41:00.000-06:00",
+        "endDate": "2015-07-09T09:41:00.000-06:00",
+        "note": "ADAPS Source Flag: *"
+      }
+    ],
+    /* This has bogus approval descriptions to test that we are not matching on the descriptions.
+    It also has an added approval level '3' to test how we handle new levels being added. */
+    "approvals": [
+      {
+        "level": 2,
+        "description": "Approved! Yep",
+        "comment": "",
+        "dateApplied": "2015-10-30T16:59:01.353Z",
+        "startTime": "2002-10-01T00:00:00.000-06:00",
+        "endTime": "2015-07-09T00:00:00.000-06:00"
+      },
+      {
+        "level": 1,
+        "description": "Still In-Review",
+        "comment": "",
+        "dateApplied": "2015-10-30T16:48:34.358Z",
+        "startTime": "2015-07-09T00:00:00.000-06:00",
+        "endTime": "2015-08-09T00:00:00.000-06:00"
+      },
+      {
+        /* Entries do not have to be unique */
+        "level": 2,
+        "description": "Approved! Yep",
+        "comment": "",
+        "dateApplied": "2015-10-30T16:59:01.353Z",
+        "startTime": "2015-08-01T00:00:00.000-06:00",
+        "endTime": "2015-09-09T00:00:00.000-06:00"
+      },
+      {
+        "level": 0,
+        "description": "Workin on it",
+        "comment": "",
+        "dateApplied": "2015-10-30T16:48:34.358Z",
+        "startTime": "2015-09-09T00:00:00.000-06:00",
+        "endTime": "2015-10-09T00:00:00.000-06:00"
+      },
+      {
+        "level": 4,
+        "description": "The gold standard",
+        "comment": "",
+        "dateApplied": "2015-10-30T16:48:34.358Z",
+        "startTime": "2015-10-09T00:00:00.000-06:00",
+        "endTime": "2015-11-09T00:00:00.000-06:00"
+      }
+    ],
+    "name": "164f1cf5deea4382831a6139bc4cd813",
+    "isVolumetricFlow": true,
+    "description": "From Aquarius",
+    "qualifiers": [],
+    "units": "ft^3/s",
+    "grades": [
+      {
+        "startDate": "2015-04-01T00:00:00.000-06:00",
+        "endDate": "2016-04-11T00:00:00.000-06:00",
+        "code": "0"
+      }
+    ],
+    "type": "Discharge",
+    "points": []
+  },
+  "corrections": {
+    "PreProcessing": [
+      {
+        "appliedTimeUtc": "2015-10-28T22:58:28.319Z",
+        "comment": "ADAPS Flag Code: U",
+        "startTime": "2015-09-23T23:00:00.000-06:00",
+        "endTime": "2015-09-24T04:30:00.000-06:00",
+        "type": "DELETE_REGION",
+        "parameters": "{}",
+        "user": "admin",
+        "processingOrder": "PRE_PROCESSING"
+      }
+    ],
+    "PostProcessing": [
+      {
+        "appliedTimeUtc": "2015-10-28T22:58:28.319Z",
+        "comment": "Approval period copy paste from Ref",
+        "startTime": "2015-03-05T00:00:00.000-06:00",
+        "endTime": "2015-05-20T00:00:00.000-06:00",
+        "type": "COPY_PASTE",
+        "parameters": "{}",
+        "user": "admin",
+        "processingOrder": "POST_PROCESSING"
+      },
+      {
+        "appliedTimeUtc": "2015-10-28T22:58:28.319Z",
+        "comment": "Approval period copy paste from Ref",
+        "startTime": "2015-05-20T00:00:00.000-06:00",
+        "endTime": "2015-07-09T00:00:00.000-06:00",
+        "type": "COPY_PASTE",
+        "parameters": "{}",
+        "user": "admin",
+        "processingOrder": "POST_PROCESSING"
+      }
+    ],
+    "Normal": []
+  },
+  "reportMetadata": {
+    "country": "United States of America",
+    "altitude": "  803.43",
+    "requestingUser": "dpattermann",
+    "agency": "USGS ",
+    "endDate": "2016-04-11T00:00:00-05:00",
+    "drainageArea": "   64.17",
+    "requestDateTime": "2016-04-11T13:42:00.473-05:00",
+    "nwisRaAuthToken": "0b257a48-ac2f-4c5f-8725-3c342a1dfb9e",
+    "latitude": "38.9383333333333",
+    "county": "Johnson County",
+    "description": "Shows overview of correction information",
+    "title": "Corrections At a Glance",
+    "longitute": "-94.6077777777778",
+    "primaryParameter": "Discharge.ft^3/s@06893390",
+    "primaryTsIdentifier": "164f1cf5deea4382831a6139bc4cd813",
+    "requestId": "341dc7d8-366b-49d4-a455-5b7e8873ddd2",
+    "contributingDrainageArea": "   64.17",
+    "altitudeDatumCode": "NAVD88    ",
+    "siteNumber": "06893390       ",
+    "stationName": "INDIAN C AT STATE LINE RD, LEAWOOD, KS",
+    "coordinateDatumCode": "NAD83     ",
+    "state": "Kansas",
+    "startDate": "2015-04-01T00:00:00-05:00",
+    "stationId": "06893390"
+  },
+  "fieldVisits": [
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-05-08T09:05:00.000-06:00",
+      "endTime": "2015-05-08T23:59:59.000-06:00",
+      "identifier": "235661642D621547E0530100007F5268",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:07:23.792-06:00",
+      "party": "Cd, CRP",
+      "remarks": "Visit end time not specified on input file. 23:59 (UTC-6:00) assumed.\r\nCleaned monitors; river was up and swift-no field monitor deployed; changed NO3 battery. Cleaning visit during/after rise. River was up and moving swiftly--didn\u0027t feel comfortable setting field monitor along bank. No field measurements taken. Changed NO3 batteries.\r\ngoto gap and shift",
+      "weather": "cloudy, warm, no precip, light wind, swirling/variable"
+    },
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-05-28T10:30:00.000-06:00",
+      "endTime": "2015-05-28T23:59:59.000-06:00",
+      "identifier": "235661642D631547E0530100007F5268",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:04:56.424-06:00",
+      "party": "CRP",
+      "remarks": "Visit end time not specified on input file. 23:59 (UTC-6:00) assumed.\r\nReplaced nitratax batteries.",
+      "weather": ""
+    },
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-05-13T10:23:00.000-06:00",
+      "endTime": "2015-05-13T13:00:08.000-06:00",
+      "identifier": "23565EDAD33111F3E0530100007FD285",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:07:24.527-06:00",
+      "party": "Cd",
+      "remarks": "replaced accububbler w/DA H-3553 gas purge system and large desicant cylinder",
+      "weather": "partly cloudy, warm, no precip, moderate-swirling/variable wind"
+    },
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-05-20T09:10:00.000-06:00",
+      "endTime": "2015-05-20T09:46:10.000-06:00",
+      "identifier": "23565EDAD33211F3E0530100007FD285",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:07:25.541-06:00",
+      "party": "ALR",
+      "remarks": "high flow qm....updated 07/22/2015 by mmay: changed discharge to 1827 per new WinRiverII software version",
+      "weather": "cloudy, cool, mist, light wind, blowing cross stream"
+    },
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-05-27T13:45:00.000-06:00",
+      "endTime": "2015-05-27T14:30:00.000-06:00",
+      "identifier": "23565EDAD33311F3E0530100007FD285",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:07:26.499-06:00",
+      "party": "CRP",
+      "remarks": "Cleaning after rise;  FM was lab monitor (SN 14M100756).",
+      "weather": "Hot, Humid, Clear, Calm"
+    },
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-06-18T10:00:00.000-06:00",
+      "endTime": "2015-06-18T11:00:00.000-06:00",
+      "identifier": "23565EDAD33411F3E0530100007FD285",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:07:27.553-06:00",
+      "party": "CRP",
+      "remarks": "Cleaning visit; FM was tie dye (SN: 14M100756).\nSticks and moss around monitor and sediment packed into pipe. Final readings taken from gagehouse may be more accurate compared to after-cleaning readings from field-monitor, as nitratax reading had not updated at 1145; no final readings taken from stream.",
+      "weather": "Warm, Humid, Pt Cloudy"
+    },
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-04-14T11:30:00.000-06:00",
+      "endTime": "2015-04-14T12:30:00.000-06:00",
+      "identifier": "23565EDAD32E11F3E0530100007FD285",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:07:20.027-06:00",
+      "party": "CRP",
+      "remarks": "Replaced nitratax batteries and cleaned monitor.  Field monitor was blue. (SN: 12G104000)",
+      "weather": "Warm"
+    },
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-04-22T11:20:00.000-06:00",
+      "endTime": "2015-04-22T12:15:00.000-06:00",
+      "identifier": "23565EDAD32F11F3E0530100007FD285",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:07:21.015-06:00",
+      "party": "PE",
+      "remarks": "Field meter was blue (SN: 12G104000), but there are no measurements because it would not connect to the handheld.",
+      "weather": ""
+    },
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-05-04T10:06:00.000-06:00",
+      "endTime": "2015-05-04T12:15:15.000-06:00",
+      "identifier": "23565EDAD33011F3E0530100007FD285",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:07:22.121-06:00",
+      "party": "Cd",
+      "remarks": "time to measure",
+      "weather": "partly cloudy, warm, no precip, light-swirling/variable wind"
+    },
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-07-09T09:33:00.000-06:00",
+      "endTime": "2015-07-09T10:37:16.000-06:00",
+      "identifier": "23565EDAD33511F3E0530100007FD285",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:07:28.546-06:00",
+      "party": "Cd",
+      "remarks": "time to measure, installed in-line fuse holder to satlink (8 amp), hwm at 4.74 ft above BOS CSG, 2nd mark 0.68 ft above BOS",
+      "weather": "partly cloudy, warm, no precip, light-swirling/variable wind"
+    },
+    {
+      "locationIdentifier": "06893390",
+      "startTime": "2015-09-04T10:14:00.000-06:00",
+      "endTime": "2015-09-04T11:51:03.000-06:00",
+      "identifier": "23565EDAD33711F3E0530100007FD285",
+      "isValid": true,
+      "lastModified": "2015-10-30T11:07:30.323-06:00",
+      "party": "Cd",
+      "remarks": "time to meas, hwm 6.34 ft above bos csg",
+      "weather": "clear, hot, no precip, light-swirling/variable wind"
+    }
+  ]
+}


### PR DESCRIPTION
This was caused by using the description as the 'key' - now using the numeric level
- Levels 0, 1 & 2 now matched instead of description text
- New/future approval types (levels other than 0-2) will default to grey
- new correctionsataglance-example5.json used to validate (how to wire up for testing??)
