### PR TITLE
Switched strategies to bound based on min/max of the corrected values only

### DIFF
--- a/R/uvhydrograph-data.R
+++ b/R/uvhydrograph-data.R
@@ -13,8 +13,7 @@ parseUVData <- function(data, plotName, month) {
     
     corr_UV <- subsetByMonth(getUvHydro(data, "primarySeries" ), month)
     est_UV <- subsetByMonth(getUvHydro(data, "primarySeries", estimatedOnly=TRUE), month)
-    uncorr_UV <- subsetByMonth(getUvHydro(data, "primarySeriesRaw" ), month) %>% 
-      omitRawExtremes(correctedData = corr_UV)
+    uncorr_UV <- subsetByMonth(getUvHydro(data, "primarySeriesRaw" ), month)
     comp_UV <- subsetByMonth(getUvHydro(data, "comparisonSeries" ), month)
     water_qual <- subsetByMonth(getWaterQualityMeasurements(data), month)
     
@@ -315,11 +314,4 @@ getInverted <- function(data, renderName, plotName) {
   
   isInverted <- ifelse(!is.null(dataName), data[[dataName]][['inverted']], NA)
   return(isInverted)
-}
-
-omitRawExtremes <- function(rawData, correctedData){
-  rawData_to_plot <- left_join(correctedData, rawData, by = "time") %>% 
-    select(-value.x, -month.x) %>% 
-    rename(value = value.y, month = month.y)
-  return(rawData_to_plot)
 }

--- a/R/uvhydrograph-render.R
+++ b/R/uvhydrograph-render.R
@@ -41,8 +41,7 @@ createPrimaryPlot <- function(data, month){
     plotStartDate <- primaryInfo$plotDates[1]
     
     plot_object <- gsplot(ylog=primaryInfo$logAxis, yaxs='r', xaxs='r') %>% 
-      lines(as.POSIXct(NA), as.numeric(NA), xlim=c(plotStartDate, 
-                                                   plotEndDate)) %>% 
+      lines(as.POSIXct(NA), as.numeric(NA), xlim=c(plotStartDate, plotEndDate), ylim=c(min(primaryData$corr_UV$value), max(primaryData$corr_UV$value))) %>% 
       axis(side=1, at=primaryInfo$plotDates, labels=as.character(primaryInfo$days)) %>%
       axis(side=2, reverse=primaryInfo$isInverted, las=0) %>%
       grid(nx=0, ny=NULL, equilogs=FALSE, lty=3, col="gray", legend.name="horizontalGrids") %>% 


### PR DESCRIPTION
This eliminates the need to attempt to match the corrected values to the uncorrected values, which may have different timezones or be interpolated after downsampling.
