### PR TITLE
adding time back to points based on feedback from AQCU-744

### DIFF
--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -193,7 +193,13 @@ getApprovals <- function(data, chain_nm, legend_nm, appr_var_all, month=NULL, po
     for(i in seq_along(date_index_list)){
       d <- date_index_list[[i]]
       
-      applicable_dates <- points[['time']][d] + hours(23) + minutes(59)
+      title <- getReportMetadata(data, 'title')
+      #result <- !objectName %in% listObjects
+      if (grepl(title, 'DV Hydrograph')) {
+        applicable_dates <- points[['time']][d] + hours(23) + minutes(59)
+      } else {
+        applicable_dates <- points[['time']][d]
+      }
         
       #use the Y values of the points, otherwise line at bottom
       if(!approvalsAtBottom){

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -193,7 +193,7 @@ getApprovals <- function(data, chain_nm, legend_nm, appr_var_all, month=NULL, po
     for(i in seq_along(date_index_list)){
       d <- date_index_list[[i]]
       
-      applicable_dates <- points[['time']][d]
+      applicable_dates <- points[['time']][d] + hours(23) + minutes(59)
         
       #use the Y values of the points, otherwise line at bottom
       if(!approvalsAtBottom){


### PR DESCRIPTION
@lindsaycarr will this cause negative impacts on the other reports which use the getApprovals function?

For AQCU-744, in order to expand the approval lines at the bottom of the graph into the "day" rather than stop on the start of the day because it only has a date to work with that it's grabbing from the firstDownChain dataset, I'm adding in the + hours + minutes to push it into the day itself. 

I'm asking Laura to verify it looks right on the ticket, too. Just wondering if this will create erroneous representations for the other reports and if so, is there an alternative way to achieve this without impacting those.
