### PR TITLE
A fix for AQCU-770

### DIFF
--- a/R/utils-shared.R
+++ b/R/utils-shared.R
@@ -219,5 +219,5 @@ isEmptyOrBlank <- function(val = NULL, listObjects = NULL, objectName = NULL){
 isEmptyVar <- function(variable){
   all(!is.null(variable), 
       nrow(variable) != 0 || is.null(nrow(variable)), 
-      length(variable$time[!is.na(variable$time)]) != 0 & length(variable$value) != 0)
+      length(variable$time[!is.na(variable$time)]) != 0)
 }

--- a/R/utils-shared.R
+++ b/R/utils-shared.R
@@ -219,5 +219,5 @@ isEmptyOrBlank <- function(val = NULL, listObjects = NULL, objectName = NULL){
 isEmptyVar <- function(variable){
   all(!is.null(variable), 
       nrow(variable) != 0 || is.null(nrow(variable)), 
-      length(variable$time[!is.na(variable$time)]) != 0 & length(variable$value[!is.na(variable$value)]) != 0)
+      length(variable$time[!is.na(variable$time)]) != 0 & length(variable$value) != 0)
 }


### PR DESCRIPTION
A bit too aggressive for the uvhydrograph corrections, because the value for those correction comments are NA and this statement in its previous state removes them from the allVars variables

I tested this with five year gw summary and dvhydrograph, because they also use the function but it doesn't seem to affect the test datasets I have here, hoping @lindsaycarr can take a peek before I merge.
