### PR TITLE
change approval line style

### DIFF
--- a/R/dvhydrograph-data.R
+++ b/R/dvhydrograph-data.R
@@ -14,7 +14,7 @@ parseDVData <- function(data){
   min_iv <- getMaxMinIv(data, 'MIN')
   
   approvals <- getApprovals(data, chain_nm="firstDownChain", legend_nm=data[['reportMetadata']][["downChainDescriptions1"]],
-                            appr_var_all=c("appr_approved", "appr_inreview", "appr_working"), applyFakeTime=TRUE)
+                            appr_var_all=c("appr_approved", "appr_inreview", "appr_working"), applyFakeTime=TRUE, point_type=73)
   
   if ("fieldVisitMeasurements" %in% names(data)) {
     meas_Q <- getFieldVisitMeasurementsQPoints(data) 
@@ -57,7 +57,7 @@ parseRefData <- function(data, series) {
   
   # add in approval lines from primary plot
   approvals <- getApprovals(data, chain_nm=ref_name, legend_nm=data[['reportMetadata']][[legend_name]],
-                            appr_var_all=c("appr_approved", "appr_inreview", "appr_working"))
+                            appr_var_all=c("appr_approved", "appr_inreview", "appr_working"), point_type=73)
 
   allVars <- as.list(environment())
   allVars <- append(approvals, allVars)

--- a/R/dvhydrograph-render.R
+++ b/R/dvhydrograph-render.R
@@ -29,7 +29,7 @@ createDvhydrographPlot <- function(data){
       axis(1, at=plotDates, labels=format(plotDates, "%b\n%d"), padj=0.5) %>%
       axis(2, reverse=isInverted) %>%
       view(xlim=c(startDate, endDate)) %>% 
-      legend(location="below", cex=0.8) %>%
+      legend(location="below", cex=0.8, y.intersp=1.5) %>%
       title(main="DV Hydrograph", 
             ylab = paste0(data$firstDownChain$type, ", ", data$firstDownChain$units),
             line=3)
@@ -82,7 +82,7 @@ createRefPlot <- function(data, series) {
       title(main=paste(ref_name_capital, "Reference Time Series"), 
             ylab = paste(data[[ref_name]]$type, data[[ref_name]]$units),
             line=3) %>% 
-      legend(location="below", cex=0.8)
+      legend(location="below", cex=0.8, y.intersp=1.5)
     
     for (i in 1:length(refData)) {
       refStyles <- getDvStyle(refData[i])

--- a/R/dvhydrograph-styles.R
+++ b/R/dvhydrograph-styles.R
@@ -25,9 +25,9 @@ getDvStyle <- function(data, info = NULL, ...){
                    max_iv = list(points = list(x=x, y=y, col="red", pch=8, cex=2, legend.name=paste(args$maxLabel, info$type, ":", y))),
                    min_iv = list(points = list(x=x, y=y, col="blue", pch=8, cex=2, legend.name=paste(args$minLabel, info$type, ":", y))), 
                    
-                   appr_approved = list(points = list(x=x, y=y, col="lightskyblue", type='l', lwd=15, bg="lightskyblue", legend.name=legend.name, where='first')),
-                   appr_inreview = list(points = list(x=x, y=y, col="yellow2", type='l', lwd=15, bg="yellow2", legend.name=legend.name, where='first')),
-                   appr_working = list(points = list(x=x, y=y, col="lightpink", type='l', lwd=15, bg="lightpink", legend.name=legend.name, where='first')))
+                   appr_approved = list(points = list(x=x, y=y, col="lightskyblue", type='p', pch=data[[1]]$point_type, cex=2.5, bg="lightskyblue", legend.name=legend.name, where='first')),
+                   appr_inreview = list(points = list(x=x, y=y, col="yellow2", type='p', pch=data[[1]]$point_type, cex=2.5, bg="yellow2", legend.name=legend.name, where='first')),
+                   appr_working = list(points = list(x=x, y=y, col="lightpink", type='p', pch=data[[1]]$point_type, cex=2.5, bg="lightpink", legend.name=legend.name, where='first')))
   
   return(styles)
 }

--- a/R/fiveyeargwsum-data.R
+++ b/R/fiveyeargwsum-data.R
@@ -11,7 +11,7 @@ parseFiveYrData <- function(data){
   min_iv <- getMaxMinIv_fiveyr(data, 'MIN')
   
   approvals <- getApprovals(data, chain_nm=stat_info$data_nm, legend_nm=data[['reportMetadata']][[stat_info$descr_nm]], 
-                                   appr_var_all=c("appr_approved", "appr_inreview", "appr_working"))
+                                   appr_var_all=c("appr_approved", "appr_inreview", "appr_working"), point_type=73)
   
   gw_level <- getGroundWaterLevels(data)
   

--- a/R/fiveyeargwsum-render.R
+++ b/R/fiveyeargwsum-render.R
@@ -28,7 +28,7 @@ createfiveyeargwsumPlot <- function(data){
       view(xlim=c(fiveyrInfo$startDate, fiveyrInfo$endDate)) %>%
       mtext(text=fiveyrInfo$month_label, at=fiveyrInfo$month_label_location, cex=0.5, side=1) %>% 
       mtext(text=year(fiveyrInfo$date_seq_yr), at=fiveyrInfo$date_seq_yr+(60*60*24*30*6), line=1, side=1) %>% 
-      legend(location="below", cex=0.8, ncol=2) %>% 
+      legend(location="below", cex=0.8, ncol=2, y.intersp=1.5) %>% 
       axis(side=2, reverse=isInverted) %>% 
       grid(col="lightgrey", lty=1) %>% 
       title(main=data$reportMetadata$title,

--- a/R/fiveyeargwsum-styles.R
+++ b/R/fiveyeargwsum-styles.R
@@ -11,9 +11,9 @@ getFiveyearStyle <- function(data, info=NULL, ...) {
                      max_iv = list(points = list(x=x, y=y, col="red", pch=8, cex=2, legend.name=paste(args$maxLabel, info$type, ":", y))),
                      min_iv = list(points = list(x=x, y=y, col="blue", pch=8, cex=2, legend.name=paste(args$minLabel, info$type, ":", y))),
                      gw_level = list(points = list(x=x,y=y, pch = 8, bg = 'orange', col = 'orange', cex = 1.2, lwd=1, legend.name="Measured Water Level (NWIS-RA)")),
-                     appr_approved = list(points = list(x=x, y=y, col="lightskyblue", type='l', lwd=15, bg="lightskyblue", legend.name=legend.name, where='first')),
-                     appr_inreview = list(points = list(x=x, y=y, col="yellow2", type='l', lwd=15, bg="yellow2", legend.name=legend.name, where='first')),
-                     appr_working = list(points = list(x=x, y=y, col="lightpink", type='l', lwd=15, bg="lightpink", legend.name=legend.name, where='first'))
+                     appr_approved = list(points = list(x=x, y=y, col="lightskyblue", type='p', pch=data[[1]]$point_type, cex=2.5, bg="lightskyblue", legend.name=legend.name, where='first')),
+                     appr_inreview = list(points = list(x=x, y=y, col="yellow2", type='p', pch=data[[1]]$point_type, cex=2.5, bg="yellow2", legend.name=legend.name, where='first')),
+                     appr_working = list(points = list(x=x, y=y, col="lightpink", type='p', pch=data[[1]]$point_type, cex=2.5, bg="lightpink", legend.name=legend.name, where='first'))
                      )
     
     return(styles)

--- a/R/uvhydrograph-data.R
+++ b/R/uvhydrograph-data.R
@@ -22,7 +22,7 @@ parseUVData <- function(data, plotName, month) {
     
     approvals_uv <- getApprovals(data, chain_nm="downsampledPrimarySeries", legend_nm=paste("UV", getTimeSeriesLabel(data, "downsampledPrimarySeries")),
                                         appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv"), 
-                                        subsetByMonth=TRUE, month=month)
+                                        subsetByMonth=TRUE, month=month, point_type=73)
     approvals_dv_max <- getApprovals(data, chain_nm="derivedSeriesMax", legend_nm=paste("DV Max", getTimeSeriesLabel(data, "derivedSeriesMax")),
                                             appr_var_all=c("appr_approved_dv", "appr_inreview_dv", "appr_working_dv"), 
                                             subsetByMonth=TRUE, month=month, point_type=24, approvalsAtBottom=FALSE)
@@ -61,7 +61,7 @@ parseUVData <- function(data, plotName, month) {
     
     approvals <- getApprovals(data, chain_nm="downsampledSecondarySeries", legend_nm=getTimeSeriesLabel(data, "downsampledSecondarySeries"),
                               appr_var_all=c("appr_approved", "appr_inreview", "appr_working"),
-                              subsetByMonth=TRUE, month=month)
+                              subsetByMonth=TRUE, month=month, point_type=73)
   }
   
   allVars <- as.list(environment())

--- a/R/uvhydrograph-render.R
+++ b/R/uvhydrograph-render.R
@@ -85,7 +85,7 @@ createPrimaryPlot <- function(data, month){
     leg_lines <- ifelse(ncol==2, ceiling((length(legend_items) - 6)/2), 0) 
     legend_offset <- ifelse(ncol==2, 0.3+(0.005*leg_lines), 0.3)
     plot_object <- legend(plot_object, location="below", title="", ncol=ncol, 
-                      legend_offset=legend_offset, cex=0.8) %>% 
+                      legend_offset=legend_offset, cex=0.8, y.intersp=1.5) %>% 
       grid(nx=0, ny=NULL, equilogs=FALSE, lty=3, col="gray", where='first') %>%
       abline(v=primaryInfo$plotDates, lty=3, col="gray", where='first')
     
@@ -155,7 +155,7 @@ createSecondaryPlot <- function(data, month){
       legend_offset <- ifelse(ncol==2, 0.3+(0.05*leg_lines), 0.3)
     
       plot_object <- legend(plot_object, location="below", title="", ncol=ncol, 
-                                legend_offset=legend_offset, cex=0.8) %>% 
+                                legend_offset=legend_offset, cex=0.8, y.intersp=1.5) %>% 
         grid(nx=0, ny=NULL, equilogs=FALSE, lty=3, col="gray") %>% 
         abline(v=secondaryInfo$plotDates, lty=3, col="gray")
       

--- a/R/uvhydrograph-styles.R
+++ b/R/uvhydrograph-styles.R
@@ -20,9 +20,9 @@ getUvStyle <- function(data, info, correctionLabels, plotName) {
                               points=list(x=x, y=y, pch = 21, bg = 'black', col = 'black', cex = .8, lwd=1),
                               callouts=list(x=x, y=y, labels = data$meas_Q$n, cex = .75, col='red', length = 0.05)),
 
-                appr_approved_uv = list(points = list(x=x, y=y, col="lightskyblue", type='l', lwd=15, bg="lightskyblue", legend.name=legend.name, where='first')),
-                appr_inreview_uv = list(points = list(x=x, y=y, col="yellow2", type='l', lwd=15, bg="yellow2", legend.name=legend.name, where='first')),
-                appr_working_uv = list(points = list(x=x, y=y, col="lightpink", type='l', lwd=15, bg="lightpink", legend.name=legend.name, where='first')),
+                appr_approved_uv = list(points = list(x=x, y=y, col="lightskyblue", type='p', pch=data[[1]]$point_type, cex=2.5, bg="lightskyblue", legend.name=legend.name, where='first')),
+                appr_inreview_uv = list(points = list(x=x, y=y, col="yellow2", type='p', pch=data[[1]]$point_type, cex=2.5, bg="yellow2", legend.name=legend.name, where='first')),
+                appr_working_uv = list(points = list(x=x, y=y, col="lightpink", type='p', pch=data[[1]]$point_type, cex=2.5, bg="lightpink", legend.name=legend.name, where='first')),
                 
                 appr_approved_dv = list(points = list(x=x, y=y, col="black", pch=data[[1]]$point_type, bg="lightskyblue", legend.name=legend.name)),
                 appr_inreview_dv = list(points = list(x=x, y=y, col="black", pch=data[[1]]$point_type, bg="yellow2", legend.name=legend.name)),
@@ -52,9 +52,9 @@ getUvStyle <- function(data, info, correctionLabels, plotName) {
                 hwm_readings = list(points=list(x=x, y=y, col='red', pch=10, cex=1, lwd=1, legend.name="High Water Mark Readings"), 
                                     error_bar=list(x=x, y=y, y.low=data$hwm_readings$uncertainty, y.high=data$hwm_readings$uncertainty, col='blue', lwd=.7)),
                 
-                appr_approved = list(points = list(x=x, y=y, col="lightskyblue", type='l', lwd=15, bg="lightskyblue", legend.name=legend.name, where='first')),
-                appr_inreview = list(points = list(x=x, y=y, col="yellow2", type='l', lwd=15, bg="yellow2", legend.name=legend.name, where='first')),
-                appr_working = list(points = list(x=x, y=y, col="lightpink", type='l', lwd=15, bg="lightpink", legend.name=legend.name, where='first'))
+                appr_approved = list(points = list(x=x, y=y, col="lightskyblue", type='p', pch=data[[1]]$point_type, cex=2.5, bg="lightskyblue", legend.name=legend.name, where='first')),
+                appr_inreview = list(points = list(x=x, y=y, col="yellow2", type='p', pch=data[[1]]$point_type, cex=2.5, bg="yellow2", legend.name=legend.name, where='first')),
+                appr_working = list(points = list(x=x, y=y, col="lightpink", type='p', pch=data[[1]]$point_type, cex=2.5, bg="lightpink", legend.name=legend.name, where='first'))
                 )
   } 
   


### PR DESCRIPTION
For uvhydro, dvhydro, and fiveyrgwsum.

Now the approval line is made of points with the type "I"/73 (rather than a really thick line). I also added `y.intersp=1.5` to increase the vertical space between legend entries.
