### PR TITLE
fixing 3 errors w/ uvhydro on dev

### DIFF
--- a/R/utils-shared.R
+++ b/R/utils-shared.R
@@ -226,7 +226,6 @@ isEmptyVar <- function(variable){
 splitDataGaps <- function(data, ts, isDV){
   
   data_list <- data[[ts$field[1]]]
-  dataSplit <- list()
   
   hasGaps <- "gaps"  %in% names(data_list) && !isEmptyOrBlank(data_list$gaps)
   hasEstimatedRangesAsGaps <- !isEmptyOrBlank(ts$estimated) && !ts$estimated && 
@@ -277,13 +276,18 @@ splitDataGaps <- function(data, ts, isDV){
       dataWithoutGaps <- data.frame()
     }
     
+    dataSplit <- list()
     for(g in 1:length(startGaps)){
+      
       dataBeforeGap <- dataWithoutGaps[which(dataWithoutGaps[['time']] <= startGaps[g]),]
       dataWithoutGaps <- dataWithoutGaps[which(dataWithoutGaps[['time']] >= endGaps[g]),]
-      dataSplit <- append(dataSplit, list(dataBeforeGap))
+
+      # only add dataBeforeGap if it exists, sometimes gap dates are earlier than any data 
+      if(!isEmptyVar(dataBeforeGap)) { 
+        dataSplit <- append(dataSplit, list(dataBeforeGap))
+      }
       
-      #leave the loop when there is no data left to split
-      #sometimes gap dates don't apply to current data
+      #leave the loop when there is no data left to split, sometimes gap dates are later than any
       if(isEmptyVar(dataWithoutGaps)) { 
         break  
       }

--- a/R/utils-shared.R
+++ b/R/utils-shared.R
@@ -267,7 +267,7 @@ splitDataGaps <- function(data, ts, isDV){
     startGaps <- sort(startGaps)
     endGaps <- sort(endGaps)
 
-    ## \\ ## HACK for working with list data (fiveyr and dvhydro)
+    # working with list data (fiveyr and dvhydro)
     if(class(ts) == "list"){
       dataWithoutGaps <- data.frame(time = ts$time, value = ts$value,
                                     stringsAsFactors = FALSE)
@@ -278,11 +278,16 @@ splitDataGaps <- function(data, ts, isDV){
     }
     
     for(g in 1:length(startGaps)){
-
       dataBeforeGap <- dataWithoutGaps[which(dataWithoutGaps[['time']] <= startGaps[g]),]
       dataWithoutGaps <- dataWithoutGaps[which(dataWithoutGaps[['time']] >= endGaps[g]),]
-      
       dataSplit <- append(dataSplit, list(dataBeforeGap))
+      
+      #leave the loop when there is no data left to split
+      #sometimes gap dates don't apply to current data
+      if(isEmptyVar(dataWithoutGaps)) { 
+        break  
+      }
+      
     }
     
     if(!isEmptyVar(dataWithoutGaps)){

--- a/R/uvhydrograph-data.R
+++ b/R/uvhydrograph-data.R
@@ -250,7 +250,7 @@ getReadings <- function(ts, field) {
   
   
   return(data.frame(time=x, value=y, uncertainty=uncertainty, month=month, 
-                    field=rep(field, length(time)), stringsAsFactors = FALSE))
+                    field=rep(field, length(x)), stringsAsFactors = FALSE))
   
 }
 


### PR DESCRIPTION
1 & 2. empty data created (dataWithoutGaps & dataBeforeGaps) because gap dates did not overlap with data
3. getReadings used `length(time)` to repeat a field in a data frame when it needed `length(x)` b/c x was a subset of time
