### PR TITLE
AQCU-808: Fixed an issue where gaps for DV data were too big.

### DIFF
--- a/R/utils-shared.R
+++ b/R/utils-shared.R
@@ -333,10 +333,12 @@ applyDataGaps <- function(data, relevantData, isDV=FALSE){
   if(!isEmptyOrBlank(gapData)){
     pattern <- paste0("(", paste(names(relevantData), collapse="|"), ")")
     names(gapData) <- regmatches(names(gapData), m=regexpr(pattern, names(gapData)))
+    #add data back together
+    relevantDataWithGaps <- append(relevantData[!haveField], gapData)
+  } else {
+    relevantDataWithGaps <- relevantData
   }
   
-  #add data back together
-  relevantDataWithGaps <- append(relevantData[!haveField], gapData)
   return(relevantDataWithGaps)
 }
 

--- a/R/utils-shared.R
+++ b/R/utils-shared.R
@@ -261,7 +261,8 @@ splitDataGaps <- function(data, ts, isDV){
       endGaps <- c(endGaps, endEstimated)
     }
     
-    if(isDV){ ts$time <- flexibleTimeParse(ts$time, timezone = data$reportMetadata$timezone) }
+    #This is causing DV values to be rendered at noon instead of on the day marks. Re-enable after AQCU 816?
+    #if(isDV){ ts$time <- flexibleTimeParse(ts$time, timezone = data$reportMetadata$timezone) }
     
     startGaps <- sort(startGaps)
     endGaps <- sort(endGaps)
@@ -279,8 +280,14 @@ splitDataGaps <- function(data, ts, isDV){
     dataSplit <- list()
     for(g in 1:length(startGaps)){
       
-      dataBeforeGap <- dataWithoutGaps[which(dataWithoutGaps[['time']] <= startGaps[g]),]
-      dataWithoutGaps <- dataWithoutGaps[which(dataWithoutGaps[['time']] >= endGaps[g]),]
+      if(isDV) {
+        dataBeforeGap <- dataWithoutGaps[which(dataWithoutGaps[['time']] <= as.POSIXct(strptime(startGaps[g], "%F"))),]
+        dataWithoutGaps <- dataWithoutGaps[which(dataWithoutGaps[['time']] >= as.POSIXct(strptime(endGaps[g], "%F"))),]
+      } else {
+        dataBeforeGap <- dataWithoutGaps[which(dataWithoutGaps[['time']] <= startGaps[g]),]
+        dataWithoutGaps <- dataWithoutGaps[which(dataWithoutGaps[['time']] >= endGaps[g]),]
+      }
+      
 
       # only add dataBeforeGap if it exists, sometimes gap dates are earlier than any data 
       if(!isEmptyVar(dataBeforeGap)) { 

--- a/R/utils-shared.R
+++ b/R/utils-shared.R
@@ -261,7 +261,8 @@ splitDataGaps <- function(data, ts, isDV){
       endGaps <- c(endGaps, endEstimated)
     }
     
-    #This is causing DV values to be rendered at noon instead of on the day marks. Re-enable after AQCU 816?
+    #This is causing DV steps to be rendered at noon instead of on the day marks. 
+    #Re-enable after refactor of time parsing functions?
     #if(isDV){ ts$time <- flexibleTimeParse(ts$time, timezone = data$reportMetadata$timezone) }
     
     startGaps <- sort(startGaps)


### PR DESCRIPTION
Also includes a temporary fix for the issue where DV data was being rendered at noon instead of on the date lines. See comment on line 264.
