### PR TITLE
adding in another approval type

### DIFF
--- a/R/approval-bar-styles.R
+++ b/R/approval-bar-styles.R
@@ -32,6 +32,14 @@ getApprovalBarStyle <- function(data, ybottom, ytop) {
         col = "#DC143C", border = "#DC143C",
         legend.name = legend.name, where = 'first'
       )
+    ),
+    appr_admin_uv = list(
+      rect = list(
+        xleft = data[[1]]$x0, xright = data[[1]]$x1,
+        ybottom = ybottom, ytop = ytop,
+        col = "#4169E1", border = "#4169E1",
+        legend.name = legend.name, where = 'first'
+      )
     )
   )
   

--- a/R/correctionsataglance-data.R
+++ b/R/correctionsataglance-data.R
@@ -204,11 +204,11 @@ formatThresholdsData <- function(thresholds){
 
 # Returns just the colors, in order, for a list of approval levels
 # Known Approval Levels:
-# 0=Working, 1=In Review, 2=Approved  Anything else is colored as 'grey'
+# 0=Working, 1=In Review, 2=Approved, 3=Admin Read-Only  Anything else is colored as 'grey'
 getApprovalColors <- function(approvalLevels){
-  knownApprovalLevels <- c(0, 1, 2)
-  approvalColors <- c("#DC143C", "#FFD700", "#228B22", "grey") #Hex values are colors for known approvals.  Grey only used for possible unknown values.
-  matchApproval <- match(approvalLevels, knownApprovalLevels, 4) #Defaults to 4 which corresponds to grey for an unrecognized type
+  knownApprovalLevels <- c(0, 1, 2, 3)
+  approvalColors <- c("#DC143C", "#FFD700", "#228B22", "#4169E1", "grey") #Hex values are colors for known approvals.  Grey only used for possible unknown values.
+  matchApproval <- match(approvalLevels, knownApprovalLevels, 5) #Defaults to 5 which corresponds to grey for an unrecognized type
   colors <- approvalColors[matchApproval]
   return(colors)
 }

--- a/R/dvhydrograph-data.R
+++ b/R/dvhydrograph-data.R
@@ -14,7 +14,7 @@ parseDVData <- function(data){
   min_iv <- getMaxMinIv(data, 'MIN')
   
   approvals <- getApprovals(data, chain_nm="firstDownChain", legend_nm=data[['reportMetadata']][["downChainDescriptions1"]],
-                            appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv"), applyFakeTime=TRUE, point_type=73, extendToWholeDays=TRUE)
+                            appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv", "appr_admin_uv"), applyFakeTime=TRUE, point_type=73, extendToWholeDays=TRUE)
   
   if ("fieldVisitMeasurements" %in% names(data)) {
     meas_Q <- getFieldVisitMeasurementsQPoints(data) 
@@ -60,7 +60,7 @@ parseRefData <- function(data, series) {
   
   # add in approval lines from primary plot
   approvals <- getApprovals(data, chain_nm=ref_name, legend_nm=data[['reportMetadata']][[legend_name]],
-                            appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv"), point_type=73, extendToWholeDays=TRUE)
+                            appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv", "appr_admin_uv"), point_type=73, extendToWholeDays=TRUE)
 
   allVars <- as.list(environment())
   allVars <- append(approvals, allVars)

--- a/R/fiveyeargwsum-data.R
+++ b/R/fiveyeargwsum-data.R
@@ -11,7 +11,7 @@ parseFiveYrData <- function(data){
   min_iv <- getMaxMinIv_fiveyr(data, 'MIN')
   
   approvals <- getApprovals(data, chain_nm=stat_info$data_nm, legend_nm=data[['reportMetadata']][[stat_info$descr_nm]], 
-                                   appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv"), point_type=73, extendToWholeDays=TRUE)
+                                   appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv", "appr_admin_uv"), point_type=73, extendToWholeDays=TRUE)
   
   gw_level <- getGroundWaterLevels(data)
   

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -218,12 +218,14 @@ getApprovals <- function(data, chain_nm, legend_nm, appr_var_all, month=NULL, po
     working_index <- getApprovalIndex(data, points, chain_nm, "Working");
     review_index <- getApprovalIndex(data, points, chain_nm, "In Review");
     approved_index <- getApprovalIndex(data, points, chain_nm, "Approved");
+    admin_index <- getApprovalIndex(data, points, chain_nm, "Admin Read-Only");
     
     review_index <- setdiff(review_index, working_index)
     approved_index <- setdiff(approved_index, working_index)
     approved_index <- setdiff(approved_index, review_index)
+    approved_index <- setdiff(approved_index, admin_index)
 
-    date_index_list <- list(list(type="Approved",approved_index), list(type="In Review",review_index), list(type="Working",working_index))
+    date_index_list <- list(list(type="Approved",approved_index), list(type="In Review",review_index), list(type="Working",working_index), list(type="Admin Read-Only", admin_index))
 
     for(sub_list in date_index_list){
       approval_info <- list()
@@ -268,6 +270,7 @@ getApprovals <- function(data, chain_nm, legend_nm, appr_var_all, month=NULL, po
       type <- data[[chain_nm]]$approvals$description
       type <- unlist(lapply(type, function(desc) {
         switch(desc,
+               "Admin Read-Only" = "appr_admin_uv",
                "Working" = "appr_working_uv",
                "In Review" = "appr_inreview_uv",
                "Approved" = "appr_approved_uv")

--- a/R/uvhydrograph-data.R
+++ b/R/uvhydrograph-data.R
@@ -29,19 +29,19 @@ parseUVData <- function(data, plotName, month) {
     }
     
     approvals_uv <- getApprovals(data, chain_nm="downsampledPrimarySeries", legend_nm=paste("UV", getTimeSeriesLabel(data, "downsampledPrimarySeries")),
-                                        appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv"), 
+                                        appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv", "appr_admin_uv"), 
                                         subsetByMonth=TRUE, month=month)
     approvals_first_stat <- getApprovals(data, chain_nm="firstDownChain", legend_nm=data[['reportMetadata']][["downChainDescriptions1"]],
-                                        appr_var_all=c("appr_approved_dv", "appr_inreview_dv", "appr_working_dv"), 
+                                        appr_var_all=c("appr_approved_dv", "appr_inreview_dv", "appr_working_dv", "appr_admin_dv"), 
                                         subsetByMonth=TRUE, month=month, point_type=21, approvalsAtBottom=FALSE)
     approvals_second_stat <- getApprovals(data, chain_nm="secondDownChain", legend_nm=data[['reportMetadata']][["downChainDescriptions2"]],
-                                        appr_var_all=c("appr_approved_dv", "appr_inreview_dv", "appr_working_dv"), 
+                                        appr_var_all=c("appr_approved_dv", "appr_inreview_dv", "appr_working_dv", "appr_admin_dv"), 
                                         subsetByMonth=TRUE, month=month, point_type=24, approvalsAtBottom=FALSE)
     approvals_third_stat <- getApprovals(data, chain_nm="thirdDownChain", legend_nm=data[['reportMetadata']][["downChainDescriptions3"]],
-                                        appr_var_all=c("appr_approved_dv", "appr_inreview_dv", "appr_working_dv"), 
+                                        appr_var_all=c("appr_approved_dv", "appr_inreview_dv", "appr_working_dv", "appr_admin_dv"), 
                                         subsetByMonth=TRUE, month=month, point_type=25, approvalsAtBottom=FALSE)
     approvals_fourth_stat <- getApprovals(data, chain_nm="fourthDownChain", legend_nm=data[['reportMetadata']][["downChainDescriptions4"]],
-                                        appr_var_all=c("appr_approved_dv", "appr_inreview_dv", "appr_working_dv"), 
+                                        appr_var_all=c("appr_approved_dv", "appr_inreview_dv", "appr_working_dv", "appr_admin_dv"), 
                                         subsetByMonth=TRUE, month=month, point_type=22, approvalsAtBottom=FALSE)
     
      
@@ -58,7 +58,7 @@ parseUVData <- function(data, plotName, month) {
       est_UV2 <- subsetByMonth(getTimeSeries(data, "downsampledReferenceSeries", estimatedOnly=TRUE), month)
       series_corr2 <- subsetByMonth(getCorrections(data, "referenceSeriesCorrections"), month)
       approvals <- getApprovals(data, chain_nm="downsampledReferenceSeries", legend_nm=getTimeSeriesLabel(data, "downsampledReferenceSeries"),
-                                  appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv"),
+                                  appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv", "appr_admin_uv"),
                                   subsetByMonth=TRUE, month=month)
     } else {
       #Upchain Time Series Data
@@ -67,7 +67,7 @@ parseUVData <- function(data, plotName, month) {
       uncorr_UV2 <- subsetByMonth(getTimeSeries(data, "downsampledUpchainSeriesRaw"), month)
       series_corr2 <- subsetByMonth(getCorrections(data, "upchainSeriesCorrections"), month)
       approvals <- getApprovals(data, chain_nm="downsampledUpchainSeries", legend_nm=getTimeSeriesLabel(data, "downsampledUpchainSeries"),
-                                 appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv"),
+                                 appr_var_all=c("appr_approved_uv", "appr_inreview_uv", "appr_working_uv", "appr_admin_uv"),
                                  subsetByMonth=TRUE, month=month)
     }
     


### PR DESCRIPTION
This isn't a top priority, just came out of the task accidentally including a different approval type called admin read-only. This trumps all other approval types. But made me wonder how extensible adding an approval type is to our current scheme. Just fiddled around for a little bit with this and checking it in here as a thing to look at sometime, but it's not urgent to resolve. Maybe as we refactor it'll be useful to consider.

not entirely sure how to include properly in the index part of utils-json, nor the extendToWholeDays

I think these two spots assume Working is God, instead of Admin Read-Only. If that's true, I can make a better guess, but should confirm first.

This is just kind of a fun add-on, since Laura accidentally included this type in the ticket initially, but also gives us a good test to ask, how do we add another approval type, when the time comes?
