### PR TITLE
ignore NAs when looking for zeros or negatives

### DIFF
--- a/R/01-repgen.R
+++ b/R/01-repgen.R
@@ -6,6 +6,3 @@ library(methods)
 
 pkg.env <- new.env()
 
-.onLoad = function(libname, pkgname){
-  setBaseURL()
-}

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -63,7 +63,7 @@ zeroValues <- function(data, val_nm){
     zeroList <- lapply(data, function(x) {any(na.omit(x[[val_nm]]) == 0)})
     zeroData <- any(unlist(unname(zeroList)))
   } else {
-    zeroData <- any(data[[val_nm]] == 0)
+    zeroData <- any(na.omit(data[[val_nm]]) == 0)
   }
   return(zeroData)
 }
@@ -75,7 +75,7 @@ negValues <- function(data, val_nm){
     negList <- lapply(data, function(x) {any(na.omit(x[[val_nm]]) < 0)})
     negData <- any(unlist(unname(negList)))
   } else {
-    negData <- any(data[[val_nm]] < 0)
+    negData <- any(na.omit(data[[val_nm]]) < 0)
   }
   return(negData)
 }


### PR DESCRIPTION
*hopefully* the final fix for AQCU-865 (optionally excluding negatives or zeros to log axes)