### PR TITLE
Omit min./max. shifts when min., max., or both are not present

### DIFF
--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -175,14 +175,45 @@ getFieldVisitMeasurementsShifts <- function(ts){
     df <- na.omit(df)
     return(df)
   }
-  y <- ts$fieldVisitMeasurements[['shiftInFeet']]
-  x <- ts$fieldVisitMeasurements[['measurementStartDate']]
-  minShift <- ts$fieldVisitMeasurements[['errorMinShiftInFeet']]
-  maxShift <- ts$fieldVisitMeasurements[['errorMaxShiftInFeet']]
+  
+  shiftInFeet <- ts$fieldVisitMeasurements[['shiftInFeet']]
+  measurementStartDate <- ts$fieldVisitMeasurements[['measurementStartDate']]
+  
+  errorMinShiftInFeet <- ts$fieldVisitMeasurements[['errorMinShiftInFeet']]
+  errorMaxShiftInFeet <- ts$fieldVisitMeasurements[['errorMaxShiftInFeet']]
+  
+  y <- c()
+  x <- c()
+  minShift <- c()
+  maxShift <- c()
+  
+  # We index by length(shiftInFeet) here, while admitting it is fairly
+  # arbitrary, because it seems like if all these vectors are not the same
+  # length, something is likely gravely wrong.
+  for (i in 1:length(shiftInFeet)) {
+    # if both min. & max. shift values are not the NA indicator
+    if (!is.na(errorMinShiftInFeet[i]) && !is.na(errorMaxShiftInFeet[i])) {
+      # use them
+      y <- c(y, shiftInFeet[i])
+      x <- c(x, measurementStartDate[i])
+      minShift <- c(minShift, errorMinShiftInFeet[i])
+      maxShift <- c(maxShift, errorMaxShiftInFeet[i])
+    }
+  }
+  
   time = as.POSIXct(strptime(x, "%FT%T"))
-  month <- format(time, format = "%y%m") #for subsetting later by month
-  return(data.frame(time=time, value=y, minShift=minShift, maxShift=maxShift, month=month, 
-                    field=rep("fieldVisitMeasurements", length(time)), stringsAsFactors = FALSE))
+  month <-
+    format(time, format = "%y%m") # for subsetting later by month
+  
+  return(
+    data.frame(
+      time = time, value = y,
+      minShift = minShift, maxShift = maxShift,
+      month = month,
+      field = rep("fieldVisitMeasurements", length(time)),
+      stringsAsFactors = FALSE
+    )
+  )
 }
 
 #'@export

--- a/R/utils-json.R
+++ b/R/utils-json.R
@@ -202,18 +202,9 @@ getFieldVisitMeasurementsShifts <- function(ts){
   }
   
   time = as.POSIXct(strptime(x, "%FT%T"))
-  month <-
-    format(time, format = "%y%m") # for subsetting later by month
-  
-  return(
-    data.frame(
-      time = time, value = y,
-      minShift = minShift, maxShift = maxShift,
-      month = month,
-      field = rep("fieldVisitMeasurements", length(time)),
-      stringsAsFactors = FALSE
-    )
-  )
+  month <- format(time, format = "%y%m") #for subsetting later by month
+  return(data.frame(time=time, value=y, minShift=minShift, maxShift=maxShift, month=month, 
+                    field=rep("fieldVisitMeasurements", length(time)), stringsAsFactors = FALSE))
 }
 
 #'@export

--- a/R/uvhydrograph-render.R
+++ b/R/uvhydrograph-render.R
@@ -269,6 +269,7 @@ createSecondaryPlot <- function(data, month, useDownsampled=FALSE){
 #' Add UV hydrograph objects to a plot object.
 #' @param object A gsplot, plot object.
 #' @param data Time series data to add to hydrograph.
+#' @param info Meta-data about time series data in "data" parameter.
 #' @param plotName Plot name string. Presently an element of
 #'                 domain {primary,secondary}.
 #' @param dataSides Sides data frame. See getUvStyle().

--- a/man/PlotUVHydrographObject.Rd
+++ b/man/PlotUVHydrographObject.Rd
@@ -11,6 +11,8 @@ PlotUVHydrographObject(object, data, info, plotName, dataSides, dataLimits)
 
 \item{data}{Time series data to add to hydrograph.}
 
+\item{info}{Meta-data about time series data in "data" parameter.}
+
 \item{plotName}{Plot name string. Presently an element of
 domain {primary,secondary}.}
 


### PR DESCRIPTION
Modified to omit plotting of min./max. shifts on UV hydrographs when min., max., or both are not present in data.