### PR TITLE
drop sensorreading-render file (?!)

### DIFF
--- a/R/sensorreading-render.R
+++ b/R/sensorreading-render.R
@@ -1,7 +1,0 @@
-sensorreadingReport <- function(reportObject) {
-  
-  tbl <- sensorreadingTable(reportObject)
-  formTable <- padTable(tbl)
-  cat(formTable)
-}
-


### PR DESCRIPTION
noticed we're not even using the sensorreading-render (or the sitevisitpeak-render or extremes-render for that matter) 

removing it since we already call the sensorreadingTable function directly from the Rmd

This also means the padTable function can be removed :)