### PR TITLE
AQCU-1015: Updated neareastcorrected* and nearestraw*…

### DIFF
--- a/R/sensorreading-data.R
+++ b/R/sensorreading-data.R
@@ -65,12 +65,12 @@ formatSensorData <- function(readings, columnNames, includeComments){
     listElements <- readings[listRows,]
     
     timeFormatted <- timeFormatting(listElements[["displayTime"]], "%m/%d/%Y")
-    timeFormattedCorrected <- timeFormatting(listElements[["nearestcorrectedTime"]], "%m/%d/%Y")
+    timeFormattedCorrected <- timeFormatting(listElements[["nearestCorrectedTime"]], "%m/%d/%Y")
 
     rec <- getRecorderWithinUncertainty(listElements[["uncertainty"]], listElements[["value"]], listElements[["recorderValue"]])
     ind <- getIndicatedCorrection(listElements[["recorderValue"]], listElements[["value"]])
-    app <- getAppliedCorrection(listElements[["nearestrawValue"]], listElements[["nearestcorrectedValue"]])
-    corr <- getCorrectedRef(listElements[["value"]], listElements[["nearestcorrectedValue"]], listElements[["uncertainty"]])
+    app <- getAppliedCorrection(listElements[["nearestRawValue"]], listElements[["nearestCorrectedValue"]])
+    corr <- getCorrectedRef(listElements[["value"]], listElements[["nearestCorrectedValue"]], listElements[["uncertainty"]])
     
     qual <- formatQualifiersStringList(as.data.frame(listElements[["qualifiers"]]))
 
@@ -94,7 +94,7 @@ formatSensorData <- function(readings, columnNames, includeComments){
               app, 
               corr,
               ##
-              nullMask(listElements[["nearestcorrectedValue"]]),
+              nullMask(listElements[["nearestCorrectedValue"]]),
               timeFormattedCorrected[[2]],
               qual
     )
@@ -235,17 +235,17 @@ getAppliedCorrection <- function(raw, corrected) {
 #' 
 #' @param value The reading value
 #' 
-#' @param nearestcorrectedValue The nearest corrected value to the reading value
+#' @param nearestCorrectedValue The nearest corrected value to the reading value
 #'
 #' @param uncertainty The uncertainty specified for the reading value
 #' 
 #' @return Yes or No if the corrections applied are within the reference
 #' values for their specified uncertainty
 #' 
-getCorrectedRef <- function (value, nearestcorrectedValue, uncertainty) {
-  if ((!isEmpty(value)) && (!isEmpty(uncertainty)) && (!isEmpty(nearestcorrectedValue))) {
+getCorrectedRef <- function (value, nearestCorrectedValue, uncertainty) {
+  if ((!isEmpty(value)) && (!isEmpty(uncertainty)) && (!isEmpty(nearestCorrectedValue))) {
     value <- as.numeric(value) 
-    nearest <- as.numeric(nearestcorrectedValue) 
+    nearest <- as.numeric(nearestCorrectedValue) 
     unc <- as.numeric(uncertainty)
     lower <- round(value-unc, getSrsPrecision()) 
     upper <- round(value+unc, getSrsPrecision()) 

--- a/inst/extdata/sensorreadingsummary/sensorReadingSummary-example-exc-comm.json
+++ b/inst/extdata/sensorreadingsummary/sensorReadingSummary-example-exc-comm.json
@@ -10,11 +10,11 @@
       "recorderValue": "5.02",
       "recorderType": "Routine",
       "party": "ARC/SGS",
-      "nearestcorrectedValue": "5.02",
+      "nearestCorrectedValue": "5.02",
       "qualifiers": [],
-      "nearestcorrectedTime": "2016-01-06T10:15:00-05:00",
-      "nearestrawTime": "2016-01-06T10:15:00-05:00",
-      "nearestrawValue": "5.02"
+      "nearestCorrectedTime": "2016-01-06T10:15:00-05:00",
+      "nearestRawTime": "2016-01-06T10:15:00-05:00",
+      "nearestRawValue": "5.02"
     },
     {
       "displayTime": "2016-02-29T10:57:00-05:00",
@@ -26,11 +26,11 @@
       "recorderValue": "5.24",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.24",
+      "nearestCorrectedValue": "5.24",
       "qualifiers": [],
-      "nearestcorrectedTime": "2016-02-29T11:00:00-05:00",
-      "nearestrawTime": "2016-02-29T11:00:00-05:00",
-      "nearestrawValue": "5.24"
+      "nearestCorrectedTime": "2016-02-29T11:00:00-05:00",
+      "nearestRawTime": "2016-02-29T11:00:00-05:00",
+      "nearestRawValue": "5.24"
     },
     {
       "displayTime": "2016-02-29T12:31:00-05:00",
@@ -42,11 +42,11 @@
       "recorderValue": "5.21",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.19",
+      "nearestCorrectedValue": "5.19",
       "qualifiers": [],
-      "nearestcorrectedTime": "2016-02-29T12:45:00-05:00",
-      "nearestrawTime": "2016-02-29T12:45:00-05:00",
-      "nearestrawValue": "5.19"
+      "nearestCorrectedTime": "2016-02-29T12:45:00-05:00",
+      "nearestRawTime": "2016-02-29T12:45:00-05:00",
+      "nearestRawValue": "5.19"
     },
     {
       "displayTime": "2016-05-03T08:49:00-05:00",
@@ -65,11 +65,11 @@
       "value": "5.27",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.26",
+      "nearestCorrectedValue": "5.26",
       "qualifiers": [],
-      "nearestcorrectedTime": "2016-05-03T08:45:00-05:00",
-      "nearestrawTime": "2016-05-03T08:45:00-05:00",
-      "nearestrawValue": "5.26"
+      "nearestCorrectedTime": "2016-05-03T08:45:00-05:00",
+      "nearestRawTime": "2016-05-03T08:45:00-05:00",
+      "nearestRawValue": "5.26"
     },
     {
       "displayTime": "2016-05-03T11:26:00-05:00",
@@ -88,11 +88,11 @@
       "value": "5.20",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.19",
+      "nearestCorrectedValue": "5.19",
       "qualifiers": [],
-      "nearestcorrectedTime": "2016-05-03T11:30:00-05:00",
-      "nearestrawTime": "2016-05-03T11:30:00-05:00",
-      "nearestrawValue": "5.19"
+      "nearestCorrectedTime": "2016-05-03T11:30:00-05:00",
+      "nearestRawTime": "2016-05-03T11:30:00-05:00",
+      "nearestRawValue": "5.19"
     }
   ],
   "reportMetadata": {

--- a/inst/extdata/sensorreadingsummary/sensorReadingSummary-example.json
+++ b/inst/extdata/sensorreadingsummary/sensorReadingSummary-example.json
@@ -2,19 +2,19 @@
   "readings": [
     {
       "displayTime": "2014-01-15T06:32:00.000-06:00",
-      "nearestcorrectedValue": "6.23",
+      "nearestCorrectedValue": "6.23",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-01-15T07:30:00.000-05:00",
-      "nearestrawTime": "2014-01-15T07:30:00.000-05:00",
-      "nearestrawValue": "6.24"
+      "nearestCorrectedTime": "2014-01-15T07:30:00.000-05:00",
+      "nearestRawTime": "2014-01-15T07:30:00.000-05:00",
+      "nearestRawValue": "6.24"
     },
     {
       "displayTime": "2014-01-15T06:44:00.000-06:00",
-      "nearestcorrectedValue": "6.22",
+      "nearestCorrectedValue": "6.22",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-01-15T07:45:00.000-05:00",
-      "nearestrawTime": "2014-01-15T07:45:00.000-05:00",
-      "nearestrawValue": "6.23"
+      "nearestCorrectedTime": "2014-01-15T07:45:00.000-05:00",
+      "nearestRawTime": "2014-01-15T07:45:00.000-05:00",
+      "nearestRawValue": "6.23"
     },
     {
       "displayTime": "2014-01-15T07:32:00.000-05:00",
@@ -57,11 +57,11 @@
     },
     {
       "displayTime": "2014-03-04T07:55:00.000-06:00",
-      "nearestcorrectedValue": "4.34",
+      "nearestCorrectedValue": "4.34",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-03-04T09:00:00.000-05:00",
-      "nearestrawTime": "2014-03-04T09:00:00.000-05:00",
-      "nearestrawValue": "4.35"
+      "nearestCorrectedTime": "2014-03-04T09:00:00.000-05:00",
+      "nearestRawTime": "2014-03-04T09:00:00.000-05:00",
+      "nearestRawValue": "4.35"
     },
     {
       "displayTime": "2014-03-04T08:55:00.000-05:00",
@@ -103,11 +103,11 @@
       "value": "5.54",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.56",
+      "nearestCorrectedValue": "5.56",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-04-18T07:45:00.000-05:00",
-      "nearestrawTime": "2014-04-18T07:45:00.000-05:00",
-      "nearestrawValue": "5.57"
+      "nearestCorrectedTime": "2014-04-18T07:45:00.000-05:00",
+      "nearestRawTime": "2014-04-18T07:45:00.000-05:00",
+      "nearestRawValue": "5.57"
     },
     {
       "displayTime": "2014-04-18T09:54:00.000-05:00",
@@ -130,11 +130,11 @@
       "value": "5.59",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.58",
+      "nearestCorrectedValue": "5.58",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-04-18T10:00:00.000-05:00",
-      "nearestrawTime": "2014-04-18T10:00:00.000-05:00",
-      "nearestrawValue": "5.59"
+      "nearestCorrectedTime": "2014-04-18T10:00:00.000-05:00",
+      "nearestRawTime": "2014-04-18T10:00:00.000-05:00",
+      "nearestRawValue": "5.59"
     },
     {
       "displayTime": "2014-08-07T09:50:00.000-05:00",
@@ -159,11 +159,11 @@
       "value": "4.40",
       "recorderType": "Routine",
       "party": "ARC/BMG",
-      "nearestcorrectedValue": "4.39",
+      "nearestCorrectedValue": "4.39",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-08-07T09:45:00.000-05:00",
-      "nearestrawTime": "2014-08-07T09:45:00.000-05:00",
-      "nearestrawValue": "4.4"
+      "nearestCorrectedTime": "2014-08-07T09:45:00.000-05:00",
+      "nearestRawTime": "2014-08-07T09:45:00.000-05:00",
+      "nearestRawValue": "4.4"
     },
     {
       "displayTime": "2014-08-07T10:42:00.000-05:00",
@@ -188,11 +188,11 @@
       "value": "4.39",
       "recorderType": "Routine",
       "party": "ARC/BMG",
-      "nearestcorrectedValue": "4.39",
+      "nearestCorrectedValue": "4.39",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-08-07T10:45:00.000-05:00",
-      "nearestrawTime": "2014-08-07T10:45:00.000-05:00",
-      "nearestrawValue": "4.4"
+      "nearestCorrectedTime": "2014-08-07T10:45:00.000-05:00",
+      "nearestRawTime": "2014-08-07T10:45:00.000-05:00",
+      "nearestRawValue": "4.4"
     },
     {
       "displayTime": "2014-09-08T06:39:00.000-05:00",
@@ -215,11 +215,11 @@
       "value": "4.06",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "4.05",
+      "nearestCorrectedValue": "4.05",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-09-08T06:45:00.000-05:00",
-      "nearestrawTime": "2014-09-08T06:45:00.000-05:00",
-      "nearestrawValue": "4.06"
+      "nearestCorrectedTime": "2014-09-08T06:45:00.000-05:00",
+      "nearestRawTime": "2014-09-08T06:45:00.000-05:00",
+      "nearestRawValue": "4.06"
     },
     {
       "displayTime": "2014-09-08T07:40:00.000-05:00",
@@ -242,11 +242,11 @@
       "value": "4.06",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "4.05",
+      "nearestCorrectedValue": "4.05",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-09-08T07:45:00.000-05:00",
-      "nearestrawTime": "2014-09-08T07:45:00.000-05:00",
-      "nearestrawValue": "4.06"
+      "nearestCorrectedTime": "2014-09-08T07:45:00.000-05:00",
+      "nearestRawTime": "2014-09-08T07:45:00.000-05:00",
+      "nearestRawValue": "4.06"
     },
     {
       "displayTime": "2014-09-29T05:52:00.000-05:00",
@@ -271,11 +271,11 @@
       "value": "3.89",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "3.89",
+      "nearestCorrectedValue": "3.89",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-09-29T05:45:00.000-05:00",
-      "nearestrawTime": "2014-09-29T05:45:00.000-05:00",
-      "nearestrawValue": "3.9"
+      "nearestCorrectedTime": "2014-09-29T05:45:00.000-05:00",
+      "nearestRawTime": "2014-09-29T05:45:00.000-05:00",
+      "nearestRawValue": "3.9"
     },
     {
       "displayTime": "2014-09-29T07:47:00.000-05:00",
@@ -300,11 +300,11 @@
       "value": "3.88",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "3.89",
+      "nearestCorrectedValue": "3.89",
       "qualifiers": [],
-      "nearestcorrectedTime": "2014-09-29T07:45:00.000-05:00",
-      "nearestrawTime": "2014-09-29T07:45:00.000-05:00",
-      "nearestrawValue": "3.89"
+      "nearestCorrectedTime": "2014-09-29T07:45:00.000-05:00",
+      "nearestRawTime": "2014-09-29T07:45:00.000-05:00",
+      "nearestRawValue": "3.89"
     }
   ],
   "reportMetadata": {

--- a/inst/extdata/sensorreadingsummary/sensorReadingSummary-example_w_quals.json
+++ b/inst/extdata/sensorreadingsummary/sensorReadingSummary-example_w_quals.json
@@ -18,7 +18,7 @@
       "recorderType": "Unknown",
       "party": "LEF",
       "recorderUncertainty": "0.03",
-      "nearestcorrectedValue": "2.48",
+      "nearestCorrectedValue": "2.48",
       "qualifiers": [
         {
           "startDate": "2015-10-14T03:30:00-05:00",
@@ -30,9 +30,9 @@
           "dateApplied": "2016-11-01T18:25:08.5943118Z"
         }
       ],
-      "nearestcorrectedTime": "2015-10-14T12:00:00-05:00",
-      "nearestrawTime": "2015-10-14T12:00:00-05:00",
-      "nearestrawValue": "2.49"
+      "nearestCorrectedTime": "2015-10-14T12:00:00-05:00",
+      "nearestRawTime": "2015-10-14T12:00:00-05:00",
+      "nearestRawValue": "2.49"
     },
     {
       "displayTime": "2015-10-14T13:15:00-05:00",
@@ -52,7 +52,7 @@
       "value": "2.48",
       "recorderType": "Routine",
       "party": "LEF",
-      "nearestcorrectedValue": "2.48",
+      "nearestCorrectedValue": "2.48",
       "qualifiers": [
         {
           "startDate": "2015-10-14T03:30:00-05:00",
@@ -64,9 +64,9 @@
           "dateApplied": "2016-11-01T18:25:08.5943118Z"
         }
       ],
-      "nearestcorrectedTime": "2015-10-14T13:15:00-05:00",
-      "nearestrawTime": "2015-10-14T13:15:00-05:00",
-      "nearestrawValue": "2.49"
+      "nearestCorrectedTime": "2015-10-14T13:15:00-05:00",
+      "nearestRawTime": "2015-10-14T13:15:00-05:00",
+      "nearestRawValue": "2.49"
     }
   ],
   "reportMetadata": {

--- a/inst/extdata/sitevisitpeak/sitevisitpeak-example-exc-comm.json
+++ b/inst/extdata/sitevisitpeak/sitevisitpeak-example-exc-comm.json
@@ -10,11 +10,11 @@
       "recorderValue": "5.02",
       "recorderType": "Routine",
       "party": "ARC/SGS",
-      "nearestcorrectedValue": "5.02",
+      "nearestCorrectedValue": "5.02",
       "qualifiers": [],
-      "nearestcorrectedTime": "2016-01-06T10:15:00-05:00",
-      "nearestrawTime": "2016-01-06T10:15:00-05:00",
-      "nearestrawValue": "5.02"
+      "nearestCorrectedTime": "2016-01-06T10:15:00-05:00",
+      "nearestRawTime": "2016-01-06T10:15:00-05:00",
+      "nearestRawValue": "5.02"
     },
     {
       "displayTime": "2016-02-29T10:57:00-05:00",
@@ -26,11 +26,11 @@
       "recorderValue": "5.24",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.24",
+      "nearestCorrectedValue": "5.24",
       "qualifiers": [],
-      "nearestcorrectedTime": "2016-02-29T11:00:00-05:00",
-      "nearestrawTime": "2016-02-29T11:00:00-05:00",
-      "nearestrawValue": "5.24"
+      "nearestCorrectedTime": "2016-02-29T11:00:00-05:00",
+      "nearestRawTime": "2016-02-29T11:00:00-05:00",
+      "nearestRawValue": "5.24"
     },
     {
       "displayTime": "2016-02-29T12:31:00-05:00",
@@ -42,11 +42,11 @@
       "recorderValue": "5.21",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.19",
+      "nearestCorrectedValue": "5.19",
       "qualifiers": [],
-      "nearestcorrectedTime": "2016-02-29T12:45:00-05:00",
-      "nearestrawTime": "2016-02-29T12:45:00-05:00",
-      "nearestrawValue": "5.19"
+      "nearestCorrectedTime": "2016-02-29T12:45:00-05:00",
+      "nearestRawTime": "2016-02-29T12:45:00-05:00",
+      "nearestRawValue": "5.19"
     },
     {
       "displayTime": "2016-05-03T08:49:00-05:00",
@@ -65,11 +65,11 @@
       "value": "5.27",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.26",
+      "nearestCorrectedValue": "5.26",
       "qualifiers": [],
-      "nearestcorrectedTime": "2016-05-03T08:45:00-05:00",
-      "nearestrawTime": "2016-05-03T08:45:00-05:00",
-      "nearestrawValue": "5.26"
+      "nearestCorrectedTime": "2016-05-03T08:45:00-05:00",
+      "nearestRawTime": "2016-05-03T08:45:00-05:00",
+      "nearestRawValue": "5.26"
     },
     {
       "displayTime": "2016-05-03T11:26:00-05:00",
@@ -88,11 +88,11 @@
       "value": "5.20",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.19",
+      "nearestCorrectedValue": "5.19",
       "qualifiers": [],
-      "nearestcorrectedTime": "2016-05-03T11:30:00-05:00",
-      "nearestrawTime": "2016-05-03T11:30:00-05:00",
-      "nearestrawValue": "5.19"
+      "nearestCorrectedTime": "2016-05-03T11:30:00-05:00",
+      "nearestRawTime": "2016-05-03T11:30:00-05:00",
+      "nearestRawValue": "5.19"
     }
   ],
   "reportMetadata": {

--- a/man/getCorrectedRef.Rd
+++ b/man/getCorrectedRef.Rd
@@ -5,12 +5,12 @@
 \title{Are the corrected values within the reference values accounting for 
 their specified uncertainty?}
 \usage{
-getCorrectedRef(value, nearestcorrectedValue, uncertainty)
+getCorrectedRef(value, nearestCorrectedValue, uncertainty)
 }
 \arguments{
 \item{value}{The reading value}
 
-\item{nearestcorrectedValue}{The nearest corrected value to the reading value}
+\item{nearestCorrectedValue}{The nearest corrected value to the reading value}
 
 \item{uncertainty}{The uncertainty specified for the reading value}
 }

--- a/tests/testthat/test-sensorreadingsummary.R
+++ b/tests/testthat/test-sensorreadingsummary.R
@@ -30,7 +30,7 @@ test_that("get unique qualifiers", {
       "recorderValue": "5.24",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.24",
+      "nearestCorrectedValue": "5.24",
       "qualifiers": [
         {
         "startDate": "2016-02-29T10:54:41.000-05:00",
@@ -42,9 +42,9 @@ test_that("get unique qualifiers", {
         "dateApplied": "2016-03-01T22:35:14.957-06:00"
         }
       ],
-      "nearestcorrectedTime": "2016-02-29T11:00:00-05:00",
-      "nearestrawTime": "2016-02-29T11:00:00-05:00",
-      "nearestrawValue": "5.24"
+      "nearestCorrectedTime": "2016-02-29T11:00:00-05:00",
+      "nearestRawTime": "2016-02-29T11:00:00-05:00",
+      "nearestRawValue": "5.24"
       },
       {
       "displayTime": "2016-02-29T12:31:00-05:00",
@@ -56,7 +56,7 @@ test_that("get unique qualifiers", {
       "recorderValue": "5.21",
       "recorderType": "Routine",
       "party": "ARC",
-      "nearestcorrectedValue": "5.19",
+      "nearestCorrectedValue": "5.19",
       "qualifiers": [
         {
         "startDate": "2016-02-29T16:54:41.000-05:00",
@@ -68,9 +68,9 @@ test_that("get unique qualifiers", {
         "dateApplied": "2016-03-01T22:35:14.957-06:00"
         }
       ],
-      "nearestcorrectedTime": "2016-02-29T12:45:00-05:00",
-      "nearestrawTime": "2016-02-29T12:45:00-05:00",
-      "nearestrawValue": "5.19"
+      "nearestCorrectedTime": "2016-02-29T12:45:00-05:00",
+      "nearestRawTime": "2016-02-29T12:45:00-05:00",
+      "nearestRawValue": "5.19"
       }
     ],
       "reportMetadata": {
@@ -126,7 +126,7 @@ test_that('do all expected columns exist in formatted results', {
                            "recorderValue": "5.24",
                            "recorderType": "Routine",
                            "party": "ARC",
-                           "nearestcorrectedValue": "5.24",
+                           "nearestCorrectedValue": "5.24",
                            "qualifiers": [
                            {
                            "startDate": "2016-02-29T10:54:41.000-05:00",
@@ -138,9 +138,9 @@ test_that('do all expected columns exist in formatted results', {
                            "dateApplied": "2016-03-01T22:35:14.957-06:00"
                            }
                            ],
-                           "nearestcorrectedTime": "2016-02-29T11:00:00-05:00",
-                           "nearestrawTime": "2016-02-29T11:00:00-05:00",
-                           "nearestrawValue": "5.24"
+                           "nearestCorrectedTime": "2016-02-29T11:00:00-05:00",
+                           "nearestRawTime": "2016-02-29T11:00:00-05:00",
+                           "nearestRawValue": "5.24"
                            },
                            {
                            "displayTime": "2016-02-29T12:31:00-05:00",
@@ -152,7 +152,7 @@ test_that('do all expected columns exist in formatted results', {
                            "recorderValue": "5.21",
                            "recorderType": "Routine",
                            "party": "ARC",
-                           "nearestcorrectedValue": "5.19",
+                           "nearestCorrectedValue": "5.19",
                            "qualifiers": [
                            {
                            "startDate": "2016-02-29T16:54:41.000-05:00",
@@ -164,9 +164,9 @@ test_that('do all expected columns exist in formatted results', {
                            "dateApplied": "2016-03-01T22:35:14.957-06:00"
                            }
                            ],
-                           "nearestcorrectedTime": "2016-02-29T12:45:00-05:00",
-                           "nearestrawTime": "2016-02-29T12:45:00-05:00",
-                           "nearestrawValue": "5.19"
+                           "nearestCorrectedTime": "2016-02-29T12:45:00-05:00",
+                           "nearestRawTime": "2016-02-29T12:45:00-05:00",
+                           "nearestRawValue": "5.19"
                            }
                            ],
                            "reportMetadata": {
@@ -277,10 +277,10 @@ test_that('applied correction returns as expected', {
 })
 
 test_that('get Corrected reference returns value as expected', {
-  nearestcorrectedValue <- "2.48"
+  nearestCorrectedValue <- "2.48"
   uncertainty <- "0.01"
   value <- "2.48"
-  correctedRef <- repgen:::getCorrectedRef(value, nearestcorrectedValue, uncertainty)
+  correctedRef <- repgen:::getCorrectedRef(value, nearestCorrectedValue, uncertainty)
   expect_equal(correctedRef,"Yes")
 })
 

--- a/tests/testthat/test-utils-html.R
+++ b/tests/testthat/test-utils-html.R
@@ -17,11 +17,11 @@ test_that('does it replace the escaped characters with real html breaks?', {
                        "recorderValue": "5.02",
                        "recorderType": "Routine",
                        "party": "ARC/SGS",
-                       "nearestcorrectedValue": "5.02",
+                       "nearestCorrectedValue": "5.02",
                        "qualifiers": [],
-                       "nearestcorrectedTime": "2016-01-06T10:15:00-05:00",
-                       "nearestrawTime": "2016-01-06T10:15:00-05:00",
-                       "nearestrawValue": "5.02"
+                       "nearestCorrectedTime": "2016-01-06T10:15:00-05:00",
+                       "nearestRawTime": "2016-01-06T10:15:00-05:00",
+                       "nearestRawValue": "5.02"
 },
                        {
                        "displayTime": "2016-02-29T10:57:00-05:00",
@@ -33,11 +33,11 @@ test_that('does it replace the escaped characters with real html breaks?', {
                        "recorderValue": "5.24",
                        "recorderType": "Routine",
                        "party": "ARC",
-                       "nearestcorrectedValue": "5.24",
+                       "nearestCorrectedValue": "5.24",
                        "qualifiers": [],
-                       "nearestcorrectedTime": "2016-02-29T11:00:00-05:00",
-                       "nearestrawTime": "2016-02-29T11:00:00-05:00",
-                       "nearestrawValue": "5.24"
+                       "nearestCorrectedTime": "2016-02-29T11:00:00-05:00",
+                       "nearestRawTime": "2016-02-29T11:00:00-05:00",
+                       "nearestRawValue": "5.24"
                        }
                         ] }
                        ')


### PR DESCRIPTION
…to nearestCorrected* and nearestRaw*

Note that this should be merged at the same time as:

https://github.com/USGS-CIDA/AQCU/pull/662