### PR TITLE
AQCU-1008: Cannot Render Reports for Site 0357568650

### DIFF
--- a/R/vdiagram-data.R
+++ b/R/vdiagram-data.R
@@ -52,7 +52,9 @@ parseVDiagramData <- function(reportObject){
   minStage <- fetchMinStage(reportObject)
   validParam(minStage, "minStage")
   
-  numOfShifts <- sizeOf(fetchRatingShifts(reportObject))
+  ratingShifts <- fetchRatingShifts(reportObject)
+  
+  numOfShifts <- ifelse(!isEmptyOrBlank(ratingShifts), sizeOf(ratingShifts), 0)
   
   return(list(
     shiftPoints=shiftPoints, 

--- a/R/vdiagram-render.R
+++ b/R/vdiagram-render.R
@@ -9,6 +9,15 @@ renderVDiagram <- function(reportObject) {
   
   vdiagramData <- parseVDiagramData(reportObject)
   
+  possibleFields <- c("maxShift", "minShift", "shiftId")
+  relevantData <- unname(unlist(vdiagramData[possibleFields]))
+  relevantData <- relevantData[which(!is.na(relevantData))]
+  
+  #Check if we have any data to plot. If we don't, return NULL
+  if(isEmptyOrBlank(relevantData)){
+    return(NULL)
+  }
+  
   vplot <- gsplot(mar = c(7, 3, 4, 2), yaxs = "r", xaxs = "r") %>%
     points(NA, NA, ylab = styles$plot$ylab, xlab = styles$plot$xlab)
   
@@ -44,7 +53,7 @@ renderVDiagram <- function(reportObject) {
     axis(vplot, side = c(1, 2, 4), at = c(x_seq, y_seq, y_seq)) %>%
     view(side = 2, ylim = ylims)
   
-  print(vplot)
+  return(vplot)
 }
 
 addMeasurementsAndError <- function(vplot, vdiagramData, styles) {

--- a/inst/vdiagram/vdiagram.Rmd
+++ b/inst/vdiagram/vdiagram.Rmd
@@ -36,14 +36,25 @@ cat(getLogo())
 </div>
 </div>
 
-***
-`r paste("\n  Measurements with a control condition of Anchor, Cover, or Shore Ice are excluded.\n")`
 ```{r,echo=FALSE,warning=FALSE,fig.height=11,fig.width=10, results='hide', dev='svg'}
-renderVDiagram(data)
+  vplot <- renderVDiagram(data)
 ```
-`r paste("\n  Horizontal red bars at max and min gage height for the period shown.\n")`
+
+***
+`r ifelse(!is.null(vplot), paste("\n  Measurements with a control condition of Anchor, Cover, or Shore Ice are excluded.\n"), "")`
+
+```{r,echo=FALSE,warning=FALSE,fig.height=11,fig.width=10, results='hide', dev='svg'}
+  print(vplot)
+```
+
+`r ifelse(!is.null(vplot), paste("\n  Horizontal red bars at max and min gage height for the period shown.\n"), "")`
   
-`r paste(historyMeasurementsLabel(data))`
+`r ifelse(!is.null(vplot) && !isEmptyOrBlank(historyMeasurementsLabel(data)), paste(historyMeasurementsLabel(data)), "")`
+
 ```{r,echo=FALSE,warning=FALSE,fig.height=6,fig.width=7}
-vdiagramTable(data)
+if(!is.null(vplot)){
+  vdiagramTable(data)
+}
 ```
+
+#`r if(is.null(vplot)) {paste("The dataset requested is empty.")}`#

--- a/tests/testthat/test-vdiagram.R
+++ b/tests/testthat/test-vdiagram.R
@@ -35,7 +35,18 @@ test_that("vdiagram examples work", {
   expect_is(vdiagram(data), 'character')
 })
 
-
+context("testing vdiagram does not error with empty data")
+test_that("vdiagram examples work", {
+  library(jsonlite)
+  library(gsplot)
+  data <- fromJSON('{
+    "reportMetadata":{
+      "startDate": "2016-01-01T00:00:00",
+      "endDate": "2916-01-01T00:00:00"
+    }
+  }')
+  expect_is(vdiagram(data), 'character')
+})
 
 context("testing historyMeasurementsLabel when prior years historic is 0, null, positive, or negative.")
 test_that("historyMeasurementsLabel for Vdiagram works", {


### PR DESCRIPTION
After the refactor all reports were able to render except for V-Diagram. 

Fixed an issue where V-Diagram reports would error when there was no data to plot. Added a test for this case.