### PR TITLE
hoping this will curtail installing new dependencies.

### DIFF
--- a/inst/extdata/installPackages.R
+++ b/inst/extdata/installPackages.R
@@ -49,7 +49,7 @@ installPackages <- function(pkgs, lib, repos = getOption("repos")) {
         "(DESCRIPTION file of package .+ is missing or broken|no package .+ was found)",
         w))) {
         # ...install it
-        install.packages(p, lib, repos = repos)
+        install.packages(p, lib, repos = repos, upgrade_dependencies=FALSE)
       } else {
         print(w)
       }


### PR DESCRIPTION
in looking at AQCU-1009, the install of gsplot and repgen are also pulling in upstream dependencies when their versions are new. This basically leads to installing the fixed version of the dependency if it's not on the server from the fixed MRAN version, but then when gsplot or repgen are installed, they just go ahead and grab the latest and greatest. Wondering if this will prevent that from occurring. 