### PR TITLE
updating MRAN date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - Rscript -e 'remove.packages("htmlTable")' || true
 
   #Install First Set of Dependencies
-  - Rscript -e 'install.packages(c("bitops","Rcpp","digest","magrittr","stringi","stringr","yaml","evaluate","formatr","highr","R6","assertthat","lazyeval","DBI","jsonlite","brew","mime","curl","caTools","openssl","memoise","whisker","rstudioapi","git2r","withr","markdown","knitr","htmltools", "rmarkdown","RCurl","htmlTable","roxygen2","dplyr","lubridate"), repos="http://mran.microsoft.com/snapshot/2016-03-31", type="source")'
+  - Rscript -e 'install.packages(c("bitops","Rcpp","digest","magrittr","stringi","stringr","yaml","evaluate","formatr","highr","R6","assertthat","lazyeval","DBI","jsonlite","brew","mime","curl","caTools","openssl","memoise","whisker","rstudioapi","git2r","withr","markdown","knitr","htmltools", "rmarkdown","RCurl","htmlTable","roxygen2","dplyr","lubridate"), repos="http://mran.microsoft.com/snapshot/2017-02-08", type="source")'
   
   #Install a different version of HTTR
   - Rscript -e 'install.packages("httr", repos = "http://mran.microsoft.com/snapshot/2016-01-27",type="source")'

--- a/inst/extdata/installPackages.R
+++ b/inst/extdata/installPackages.R
@@ -73,7 +73,7 @@ pkgs <-
   )
 
 # all packages are held back to older, MRAN versions
-installPackages(c(pkgs, "devtools"), lib, "https://mran.microsoft.com/snapshot/2016-03-31")
+installPackages(c(pkgs, "devtools"), lib, "https://mran.microsoft.com/snapshot/2017-02-08")
 
 # reference all date/time points to UTC (which is not actually a time zone)
 Sys.setenv(TZ = "UTC")


### PR DESCRIPTION
post build-section on jenkins revised, where it won't replace updated versions of packages with our fixed versions, changing the date on mran.