### PR TITLE
AQCU-1035 CORR- Always show the threshold lane

### DIFF
--- a/R/correctionsataglance-data.R
+++ b/R/correctionsataglance-data.R
@@ -183,15 +183,8 @@ parseCorrThresholds <- function(reportObject, timezone){
   })
   
   formattedData <- list()
-  
-  #default to one empty row if there are no threshold data set to the entire time
-  #range of the report with an empty label
-  returnData <- list(
-    startDates = flexibleTimeParse(reportObject[["reportMetadata"]][["startDate"]], timezone),
-    endDates = flexibleTimeParse(reportObject[["reportMetadata"]][["endDate"]], timezone),
-    metaLabel = ""    
-  )
-  
+  returnData <- list()
+
   if(!isEmptyOrBlank(thresholdData) && nrow(thresholdData) > 0){
     for(i in seq(nrow(thresholdData))){
       threshold <- thresholdData[i,]
@@ -466,7 +459,7 @@ createPlotLanes <- function(approvalData, requiredData, requiredNames, optionalD
   allLaneData <- c(requiredData, optionalData)
   allNameData <- c(requiredNames, optionalNames)
   overlapInfo <- findOverlap(allLaneData)
-  rectHeight <- 100/(8 + 2*optionalLaneCount + overlapInfo[["totalNewLines"]])
+  rectHeight <- 100/(10 + 2*optionalLaneCount + overlapInfo[["totalNewLines"]])
   currentHeight <- 100
   bgColors <- list("white", "#CCCCCC")
 

--- a/R/correctionsataglance-data.R
+++ b/R/correctionsataglance-data.R
@@ -183,8 +183,15 @@ parseCorrThresholds <- function(reportObject, timezone){
   })
   
   formattedData <- list()
-  returnData <- list()
-
+  
+  #default to one empty row if there are no threshold data set to the entire time
+  #range of the report with an empty label
+  returnData <- list(
+    startDates = flexibleTimeParse(reportObject[["reportMetadata"]][["startDate"]], timezone),
+    endDates = flexibleTimeParse(reportObject[["reportMetadata"]][["endDate"]], timezone),
+    metaLabel = ""    
+  )
+  
   if(!isEmptyOrBlank(thresholdData) && nrow(thresholdData) > 0){
     for(i in seq(nrow(thresholdData))){
       threshold <- thresholdData[i,]

--- a/R/correctionsataglance-render.R
+++ b/R/correctionsataglance-render.R
@@ -41,8 +41,7 @@ correctionsataglanceReport <- function(reportObject) {
   dataLanes <- allLaneData[['dataLanes']]
   processOrderLabelYPos <- mean(c(dataLanes[['preData']][["laneNameYPos"]],
                                   dataLanes[['normalData']][["laneNameYPos"]],
-                                  dataLanes[['postData']][["laneNameYPos"]],
-                                  dataLanes[['thresholdData']][["laneNameYPos"]]))
+                                  dataLanes[['postData']][["laneNameYPos"]]))
   
   #Create Base Plot
   timeline <- gsplot() %>% 

--- a/R/correctionsataglance-render.R
+++ b/R/correctionsataglance-render.R
@@ -28,10 +28,10 @@ correctionsataglanceReport <- function(reportObject) {
   gradesData <- parseCorrGrades(primarySeries, timezone)
 
   #Map required and optional data and lane display names
-  requiredData <- list(preData=preData, normalData=normalData, postData=postData)
-  optionalData <- list(thresholdData=thresholdData, qualifiersData=qualifiersData, notesData=notesData, gradesData=gradesData)
-  requiredNames <- list(preData="Pre", normalData="Normal", postData="Post")
-  optionalNames <- list(thresholdData="Thresholds", qualifiersData="Qualifiers", notesData="Notes", gradesData="Grades")
+  requiredData <- list(preData=preData, normalData=normalData, postData=postData, thresholdData=thresholdData)
+  optionalData <- list(qualifiersData=qualifiersData, notesData=notesData, gradesData=gradesData)
+  requiredNames <- list(preData="Pre", normalData="Normal", postData="Post", thresholdData="Thresholds")
+  optionalNames <- list(qualifiersData="Qualifiers", notesData="Notes", gradesData="Grades")
   
   #Generate Plot Lanes for Parsed Data
   allLaneData <- createPlotLanes(approvalData, requiredData, requiredNames, optionalData, optionalNames, dateRange, startSeq, endSeq)
@@ -41,7 +41,8 @@ correctionsataglanceReport <- function(reportObject) {
   dataLanes <- allLaneData[['dataLanes']]
   processOrderLabelYPos <- mean(c(dataLanes[['preData']][["laneNameYPos"]],
                                   dataLanes[['normalData']][["laneNameYPos"]],
-                                  dataLanes[['postData']][["laneNameYPos"]]))
+                                  dataLanes[['postData']][["laneNameYPos"]],
+                                  dataLanes[['thresholdData']][["laneNameYPos"]]))
   
   #Create Base Plot
   timeline <- gsplot() %>% 
@@ -134,7 +135,7 @@ hasValidDataToPlot <- function(allLaneData){
 #' @param rectHeight The height to use for rendering the lane rectangles
 #' @return The gsplot object with the lane data plotted onto it
 plotLanes <- function(gsplotObject, laneData, laneName, dateRange, rectHeight){  
-  notOptionalLanes <- c('preData', 'normalData', 'postData')
+  notOptionalLanes <- c('preData', 'normalData', 'postData', 'thresholdData')
   
   #add rect background for processing order + any other existing lanes
   if(laneName %in% notOptionalLanes || doAddToPlot(laneData)){

--- a/tests/testthat/test-correctionsataglance.R
+++ b/tests/testthat/test-correctionsataglance.R
@@ -1074,19 +1074,18 @@ test_that("createPlotLanes properly calculates the sequence of month start dates
   expect_equal(as.numeric(approvalLane$endDates), as.numeric(repgen:::flexibleTimeParse("2017-02-01T12:12:13", timezone)))
   expect_equal(approvalLane$type, "Approval: Approved")
   expect_equal(approvalLane$colors, "#228B22")
-  expect_equal(approvalLane$approvalLabel, c(NA, "01/2017", "02/2017", "03/2017"))
+  expect_equal(approvalLane$approvalLabel, c("01/2017", "02/2017", "03/2017"))
   expect_equal(approvalLane$laneYTop, 100)
   expect_equal(approvalLane$laneYBottom, 92.3076923076923)
-  expect_equal(approvalLane$labels$text, c(NA, "01/2017", "02/2017", "03/2017"))
+  expect_equal(approvalLane$labels$text, c("01/2017", "02/2017", "03/2017"))
   expect_equal(as.numeric(approvalLane$labels$x), as.numeric(c(
-    repgen:::flexibleTimeParse("2017-01-01T12:00:00", timezone),
-    repgen:::flexibleTimeParse("2017-01-17T12:00:00", timezone), 
-    repgen:::flexibleTimeParse("2017-02-16T00:00:00", timezone),
-    repgen:::flexibleTimeParse("2017-03-05T12:00:00", timezone)
+    repgen:::flexibleTimeParse("2017-01-16T12:00:00", timezone), 
+    repgen:::flexibleTimeParse("2017-02-15T00:00:00", timezone),
+    repgen:::flexibleTimeParse("2017-03-05T00:00:00", timezone)
   )))
   labelsYPos <- (100 + 92.3076923076923)/2
-  expect_equal(approvalLane$labels$y, c(labelsYPos,labelsYPos,labelsYPos,labelsYPos))
-  expect_equal(approvalLane$labels$shift, c(FALSE,FALSE,FALSE,FALSE))
+  expect_equal(approvalLane$labels$y, c(labelsYPos,labelsYPos,labelsYPos))
+  expect_equal(approvalLane$labels$shift, c(FALSE,FALSE,FALSE))
 
   normLane <- laneData$dataLanes$normalData
   expect_is(normLane, 'list')

--- a/tests/testthat/test-correctionsataglance.R
+++ b/tests/testthat/test-correctionsataglance.R
@@ -1004,6 +1004,7 @@ test_that("createApprovalLane properly calculates the sequence of month start da
 })
 
 test_that("createPlotLanes properly calculates the sequence of month start dates", {
+  library(lubridate)
   timezone <- "Etc/GMT+5"
   dateRange <- c(repgen:::flexibleTimeParse("2017-01-01T00:00:00", timezone), repgen:::flexibleTimeParse("2017-03-09T00:00:00", timezone))
   startSeq <- repgen:::calcStartSeq(dateRange[[1]], dateRange[[2]])
@@ -1064,7 +1065,7 @@ test_that("createPlotLanes properly calculates the sequence of month start dates
 
   expect_is(laneData, 'list')
   expect_equal(length(laneData), 4)
-  expect_equal(laneData$rectHeight, 9.090909)
+  expect_equal(laneData$rectHeight, 7.69230769230769)
   expect_equal(laneData$tableLabels, c("USGS_MULTI_POINT", "ADAPS Source Flag: *"))
 
   approvalLane <- laneData$approvalLane
@@ -1073,18 +1074,19 @@ test_that("createPlotLanes properly calculates the sequence of month start dates
   expect_equal(as.numeric(approvalLane$endDates), as.numeric(repgen:::flexibleTimeParse("2017-02-01T12:12:13", timezone)))
   expect_equal(approvalLane$type, "Approval: Approved")
   expect_equal(approvalLane$colors, "#228B22")
-  expect_equal(approvalLane$approvalLabel, c("01/2017", "02/2017", "03/2017"))
+  expect_equal(approvalLane$approvalLabel, c(NA, "01/2017", "02/2017", "03/2017"))
   expect_equal(approvalLane$laneYTop, 100)
-  expect_equal(approvalLane$laneYBottom, 90.90909)
-  expect_equal(approvalLane$labels$text, c("01/2017", "02/2017", "03/2017"))
+  expect_equal(approvalLane$laneYBottom, 92.3076923076923)
+  expect_equal(approvalLane$labels$text, c(NA, "01/2017", "02/2017", "03/2017"))
   expect_equal(as.numeric(approvalLane$labels$x), as.numeric(c(
-    repgen:::flexibleTimeParse("2017-01-16T12:00:00", timezone), 
-    repgen:::flexibleTimeParse("2017-02-15T00:00:00", timezone),
-    repgen:::flexibleTimeParse("2017-03-05T00:00:00", timezone)
+    repgen:::flexibleTimeParse("2017-01-01T12:00:00", timezone),
+    repgen:::flexibleTimeParse("2017-01-17T12:00:00", timezone), 
+    repgen:::flexibleTimeParse("2017-02-16T00:00:00", timezone),
+    repgen:::flexibleTimeParse("2017-03-05T12:00:00", timezone)
   )))
-  labelsYPos <- (100 + 90.90909)/2
-  expect_equal(approvalLane$labels$y, c(labelsYPos,labelsYPos,labelsYPos))
-  expect_equal(approvalLane$labels$shift, c(FALSE,FALSE,FALSE))
+  labelsYPos <- (100 + 92.3076923076923)/2
+  expect_equal(approvalLane$labels$y, c(labelsYPos,labelsYPos,labelsYPos,labelsYPos))
+  expect_equal(approvalLane$labels$shift, c(FALSE,FALSE,FALSE,FALSE))
 
   normLane <- laneData$dataLanes$normalData
   expect_is(normLane, 'list')
@@ -1242,8 +1244,8 @@ test_that("plotLanes properly calculates the sequence of month start dates", {
     legend(x = as.numeric(median(startSeq)), 
             y = 115, bty = 'n')
 
-  plot1 <- plotLanes(basePlot, laneData$dataLanes$noteData, "noteData", dateRange, laneData$rectHeight)
-  plot2 <- plotLanes(basePlot, laneData$dataLanes$normalData, "normalData", dateRange, laneData$rectHeight)
+  plot1 <- repgen:::plotLanes(basePlot, laneData$dataLanes$noteData, "noteData", dateRange, laneData$rectHeight)
+  plot2 <- repgen:::plotLanes(basePlot, laneData$dataLanes$normalData, "normalData", dateRange, laneData$rectHeight)
 
   expect_equal(length(plot1$view.1.2), 8)
   texts1 <- gsplot:::views(plot1)[[1]][which(grepl("text", names(gsplot:::views(plot1)[[1]])))]
@@ -1272,6 +1274,7 @@ test_that("plotLanes properly calculates the sequence of month start dates", {
 
 test_that("correctionsataglanceReport properly calculates the sequence of month start dates", {
   reportObject1 <- fromJSON('{
+    "thresholds": [],
     "primarySeries":{
       "approvals":[
         {
@@ -1320,6 +1323,7 @@ test_that("correctionsataglanceReport properly calculates the sequence of month 
   }')
 
   reportObject2 <- fromJSON('{
+    "thresholds": [],
     "primarySeries":{
       "approvals":[],
       "notes": [],
@@ -1337,6 +1341,7 @@ test_that("correctionsataglanceReport properly calculates the sequence of month 
   }')
 
   reportObject3 <- fromJSON('{
+    "thresholds": [],
     "primarySeries":{
       "approvals":[],
       "notes": [],
@@ -1372,10 +1377,10 @@ test_that("correctionsataglanceReport properly calculates the sequence of month 
     }
   }')
 
-  corrData1 <- correctionsataglanceReport(reportObject1)
-  corrData2 <- correctionsataglanceReport(reportObject2)
-  corrData3 <- correctionsataglanceReport(reportObject3)
-  expect_error(correctionsataglanceReport(reportObject4), "Data for: ' primarySeries ' was not found in report JSON.")
+  corrData1 <- repgen:::correctionsataglanceReport(reportObject1)
+  corrData2 <- repgen:::correctionsataglanceReport(reportObject2)
+  corrData3 <- repgen:::correctionsataglanceReport(reportObject3)
+  expect_error(repgen:::correctionsataglanceReport(reportObject4), "Data for: ' primarySeries ' was not found in report JSON.")
 
   expect_is(corrData1, 'list')
   expect_is(corrData2, 'character')
@@ -1395,11 +1400,11 @@ test_that("correctionsataglanceReport properly calculates the sequence of month 
   ablines <- gsplot:::views(plot1)[[1]][which(grepl("abline", names(gsplot:::views(plot1)[[1]])))]
   points <- gsplot:::views(plot1)[[1]][which(grepl("points", names(gsplot:::views(plot1)[[1]])))]
 
-  expect_equal(length(texts), 9)
-  expect_equal(length(rects), 8)
-  expect_equal(length(mtext), 5)
-  expect_equal(length(ablines), 3)
-  expect_equal(length(points), 3)
+  expect_equal(length(texts), 10)
+  expect_equal(length(rects), 9)
+  expect_equal(length(mtext), 6)
+  expect_equal(length(ablines), 4)
+  expect_equal(length(points), 4)
 })
 
 test_that("parseCorrFieldVisits properly reads and formats the field visit points", {

--- a/tests/testthat/test-correctionsataglance.R
+++ b/tests/testthat/test-correctionsataglance.R
@@ -1004,6 +1004,7 @@ test_that("createApprovalLane properly calculates the sequence of month start da
 })
 
 test_that("createPlotLanes properly calculates the sequence of month start dates", {
+  library(lubridate)
   timezone <- "Etc/GMT+5"
   dateRange <- c(repgen:::flexibleTimeParse("2017-01-01T00:00:00", timezone), repgen:::flexibleTimeParse("2017-03-09T00:00:00", timezone))
   startSeq <- repgen:::calcStartSeq(dateRange[[1]], dateRange[[2]])
@@ -1064,7 +1065,7 @@ test_that("createPlotLanes properly calculates the sequence of month start dates
 
   expect_is(laneData, 'list')
   expect_equal(length(laneData), 4)
-  expect_equal(laneData$rectHeight, 9.090909)
+  expect_equal(laneData$rectHeight, 7.69230769230769)
   expect_equal(laneData$tableLabels, c("USGS_MULTI_POINT", "ADAPS Source Flag: *"))
 
   approvalLane <- laneData$approvalLane
@@ -1073,18 +1074,19 @@ test_that("createPlotLanes properly calculates the sequence of month start dates
   expect_equal(as.numeric(approvalLane$endDates), as.numeric(repgen:::flexibleTimeParse("2017-02-01T12:12:13", timezone)))
   expect_equal(approvalLane$type, "Approval: Approved")
   expect_equal(approvalLane$colors, "#228B22")
-  expect_equal(approvalLane$approvalLabel, c("01/2017", "02/2017", "03/2017"))
+  expect_equal(approvalLane$approvalLabel, c(NA, "01/2017", "02/2017", "03/2017"))
   expect_equal(approvalLane$laneYTop, 100)
-  expect_equal(approvalLane$laneYBottom, 90.90909)
-  expect_equal(approvalLane$labels$text, c("01/2017", "02/2017", "03/2017"))
+  expect_equal(approvalLane$laneYBottom, 92.3076923076923)
+  expect_equal(approvalLane$labels$text, c(NA, "01/2017", "02/2017", "03/2017"))
   expect_equal(as.numeric(approvalLane$labels$x), as.numeric(c(
-    repgen:::flexibleTimeParse("2017-01-16T12:00:00", timezone), 
-    repgen:::flexibleTimeParse("2017-02-15T00:00:00", timezone),
-    repgen:::flexibleTimeParse("2017-03-05T00:00:00", timezone)
+    repgen:::flexibleTimeParse("2017-01-01T12:00:00", timezone),
+    repgen:::flexibleTimeParse("2017-01-17T12:00:00", timezone), 
+    repgen:::flexibleTimeParse("2017-02-16T00:00:00", timezone),
+    repgen:::flexibleTimeParse("2017-03-05T12:00:00", timezone)
   )))
-  labelsYPos <- (100 + 90.90909)/2
-  expect_equal(approvalLane$labels$y, c(labelsYPos,labelsYPos,labelsYPos))
-  expect_equal(approvalLane$labels$shift, c(FALSE,FALSE,FALSE))
+  labelsYPos <- (100 + 92.3076923076923)/2
+  expect_equal(approvalLane$labels$y, c(labelsYPos,labelsYPos,labelsYPos,labelsYPos))
+  expect_equal(approvalLane$labels$shift, c(FALSE,FALSE,FALSE,FALSE))
 
   normLane <- laneData$dataLanes$normalData
   expect_is(normLane, 'list')
@@ -1242,8 +1244,8 @@ test_that("plotLanes properly calculates the sequence of month start dates", {
     legend(x = as.numeric(median(startSeq)), 
             y = 115, bty = 'n')
 
-  plot1 <- plotLanes(basePlot, laneData$dataLanes$noteData, "noteData", dateRange, laneData$rectHeight)
-  plot2 <- plotLanes(basePlot, laneData$dataLanes$normalData, "normalData", dateRange, laneData$rectHeight)
+  plot1 <- repgen:::plotLanes(basePlot, laneData$dataLanes$noteData, "noteData", dateRange, laneData$rectHeight)
+  plot2 <- repgen:::plotLanes(basePlot, laneData$dataLanes$normalData, "normalData", dateRange, laneData$rectHeight)
 
   expect_equal(length(plot1$view.1.2), 8)
   texts1 <- gsplot:::views(plot1)[[1]][which(grepl("text", names(gsplot:::views(plot1)[[1]])))]
@@ -1271,7 +1273,9 @@ test_that("plotLanes properly calculates the sequence of month start dates", {
 })
 
 test_that("correctionsataglanceReport properly calculates the sequence of month start dates", {
+  library(gsplot)
   reportObject1 <- fromJSON('{
+    "thresholds": [],
     "primarySeries":{
       "approvals":[
         {
@@ -1320,6 +1324,7 @@ test_that("correctionsataglanceReport properly calculates the sequence of month 
   }')
 
   reportObject2 <- fromJSON('{
+    "thresholds": [],
     "primarySeries":{
       "approvals":[],
       "notes": [],
@@ -1337,6 +1342,7 @@ test_that("correctionsataglanceReport properly calculates the sequence of month 
   }')
 
   reportObject3 <- fromJSON('{
+    "thresholds": [],
     "primarySeries":{
       "approvals":[],
       "notes": [],
@@ -1372,10 +1378,10 @@ test_that("correctionsataglanceReport properly calculates the sequence of month 
     }
   }')
 
-  corrData1 <- correctionsataglanceReport(reportObject1)
-  corrData2 <- correctionsataglanceReport(reportObject2)
-  corrData3 <- correctionsataglanceReport(reportObject3)
-  expect_error(correctionsataglanceReport(reportObject4), "Data for: ' primarySeries ' was not found in report JSON.")
+  corrData1 <- repgen:::correctionsataglanceReport(reportObject1)
+  corrData2 <- repgen:::correctionsataglanceReport(reportObject2)
+  corrData3 <- repgen:::correctionsataglanceReport(reportObject3)
+  expect_error(repgen:::correctionsataglanceReport(reportObject4), "Data for: ' primarySeries ' was not found in report JSON.")
 
   expect_is(corrData1, 'list')
   expect_is(corrData2, 'character')
@@ -1388,17 +1394,17 @@ test_that("correctionsataglanceReport properly calculates the sequence of month 
   expect_is(corrData1$timeline, 'gsplot')
   plot1 <- corrData1$timeline
 
-  expect_equal(length(plot1$view.1.2), 24)
+  expect_equal(length(plot1$view.1.2), 27)
   texts <- gsplot:::views(plot1)[[1]][which(grepl("text", names(gsplot:::views(plot1)[[1]])))]
   rects <- gsplot:::views(plot1)[[1]][which(grepl("rect", names(gsplot:::views(plot1)[[1]])))]
   mtext <- gsplot:::views(plot1)[[1]][which(grepl("mtext", names(gsplot:::views(plot1)[[1]])))]
   ablines <- gsplot:::views(plot1)[[1]][which(grepl("abline", names(gsplot:::views(plot1)[[1]])))]
   points <- gsplot:::views(plot1)[[1]][which(grepl("points", names(gsplot:::views(plot1)[[1]])))]
 
-  expect_equal(length(texts), 9)
-  expect_equal(length(rects), 8)
-  expect_equal(length(mtext), 5)
-  expect_equal(length(ablines), 3)
+  expect_equal(length(texts), 10)
+  expect_equal(length(rects), 9)
+  expect_equal(length(mtext), 6)
+  expect_equal(length(ablines), 4)
   expect_equal(length(points), 3)
 })
 


### PR DESCRIPTION
-creating an empty threshold row with the start/end dates from reportMetadata and a null label; if there are threshold data these are overwritten with actual data, if not, an empty row appears.