### PR TITLE
Gsplot upgrade to 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - Rscript -e 'install.packages(c("devtools", "testthat"))'
 
   #Install packages from github
-  - Rscript -e 'devtools::install_github("usgs-r/gsplot#420")'
+  - Rscript -e 'devtools::install_github("usgs-r/gsplot#469")'
   - Rscript -e 'devtools::install_github("jimhester/covr")'
   - Rscript -e 'Sys.setenv(TZ="UTC")'
 

--- a/R/dvhydrograph-render.R
+++ b/R/dvhydrograph-render.R
@@ -337,7 +337,7 @@ getDVHydrographRefPlotConfig <- function(plotItem, plotItemName, yLabel, ...){
       lines = append(list(x=x, y=y, ylab=args$yLabel, legend.name=paste("Reference 2:", legend.name)), styles$tref_lines)
     ),
     thirdReferenceTimeSeries = list(
-      lines = append(list(x=x, y=y, ylab=args$yLabel, legend.name=paste("Refernce 3:", legend.name)), styles$qref_lines)
+      lines = append(list(x=x, y=y, ylab=args$yLabel, legend.name=paste("Reference 3:", legend.name)), styles$qref_lines)
     ),
     firstReferenceTimeSeriesEst = list(
       lines = append(list(x=x, y=y, ylab=args$yLabel, legend.name=paste("Est. Reference 1:", legend.name)), styles$srefe_lines)

--- a/R/extremes-data.R
+++ b/R/extremes-data.R
@@ -229,6 +229,10 @@ createDataRows <-
       return(dataRows)
     })
 
+    # declare objects to get rid of dplyr warning in Check
+    # these are column names and will be used appropriately when it gets to that line
+    related <- time <- primary <- '.dplyr.var'
+    
     #Clean Data Rows
     if(!is.null(dataRows[[1]])){
       dataRows <- dataRows[[1]]

--- a/R/sig-dvhydrograph.R
+++ b/R/sig-dvhydrograph.R
@@ -10,7 +10,8 @@
 #' library(lubridate)
 #' library(dplyr)
 #' Sys.setenv(TZ = "UTC")
-#' reportObject <- fromJSON(system.file('extdata','testsnippets','test-dvhydrograph.json', package = 'repgen'))[['allStats']]
+#' reportObject <- fromJSON(system.file('extdata','testsnippets', 'test-dvhydrograph.json', 
+#'                                      package = 'repgen'))[['allStats']]
 #' dvhydrograph(reportObject, 'Author Name')
 #' @rdname dvhydrograph
 #' @export

--- a/R/utils-read.R
+++ b/R/utils-read.R
@@ -111,12 +111,16 @@ readFieldVisitReadings <- function(reportObject){
   requiredFields <- c('visitTime')
   returnDf <- data.frame(stringsAsFactors=FALSE)
 
+  # declare objects to get rid of dplyr warning in Check
+  # these are column names and will be used appropriately when it gets to that line
+  associatedIvValue <- visitTime <- associatedIvTime <-associatedIvQualifiers <- value <- '.dplyr.var'
+  
   if(validateFetchedData(visitReadings, "Readings", requiredFields, stopEmpty=TRUE)){
     #Move associated IV information to the highest valued reading
     if(!all(sapply(visitReadings$associatedIvValue, function(e){isEmptyOrBlank(e)}))){
-      orderedIVs <- visitReadings %>% dplyr:::mutate(sort = is.na(associatedIvValue)) %>% dplyr:::group_by(visitTime) %>% dplyr:::arrange(visitTime, sort) %>% dplyr:::ungroup() %>% dplyr:::select(associatedIvValue, associatedIvTime, associatedIvQualifiers)
-      orderedValues <- visitReadings %>% dplyr:::mutate(sort = as.numeric(value)) %>% dplyr:::group_by(visitTime) %>% dplyr:::arrange(visitTime, desc(sort)) %>% dplyr:::select(-sort, -associatedIvValue, -associatedIvTime, -associatedIvQualifiers)
-      visitReadings <- dplyr:::bind_cols(orderedValues, orderedIVs) %>% dplyr:::arrange(visitTime) %>% as.data.frame()
+      orderedIVs <- visitReadings %>% dplyr::mutate(sort = is.na(associatedIvValue)) %>% dplyr::group_by(visitTime) %>% dplyr::arrange(visitTime, sort) %>% dplyr::ungroup() %>% dplyr::select(associatedIvValue, associatedIvTime, associatedIvQualifiers)
+      orderedValues <- visitReadings %>% dplyr::mutate(sort = as.numeric(value)) %>% dplyr::group_by(visitTime) %>% dplyr::arrange(visitTime, desc(sort)) %>% dplyr::select(-sort, -associatedIvValue, -associatedIvTime, -associatedIvQualifiers)
+      visitReadings <- dplyr::bind_cols(orderedValues, orderedIVs) %>% dplyr::arrange(visitTime) %>% as.data.frame()
     }
     
     #Format the data frame to a table

--- a/R/uvhydrograph-data.R
+++ b/R/uvhydrograph-data.R
@@ -372,7 +372,7 @@ isPrimaryDischarge <- function(reportObject) {
   return(any(grepl("Discharge", fetchReportMetadataField(reportObject,'primaryParameter'))))
 }
 
-#' Has Refernce Series
+#' Has Reference Series
 #' Determines if the report has a reference series attached
 #' @param reportObject UV Hydro report object
 #' @return true/false

--- a/R/vdiagram-render.R
+++ b/R/vdiagram-render.R
@@ -22,7 +22,8 @@ renderVDiagram <- function(reportObject) {
   }
   
   vplot <- gsplot(mar = c(7, 3, 4, 2), yaxs = "r", xaxs = "r") %>%
-    points(NA, NA, ylab = styles$plot$ylab, xlab = styles$plot$xlab)
+    points(NA, NA, axes = FALSE) %>% 
+    view(ylab = styles$plot$ylab, xlab = styles$plot$xlab)
   
   vplot <- do.call(grid, append(list(object = vplot), styles$grid))
   
@@ -52,8 +53,8 @@ renderVDiagram <- function(reportObject) {
   vplot <-
     do.call(abline, append(list(object = vplot, v = x_seq), styles$ablines))
   
-  vplot <-
-    axis(vplot, side = c(1, 2, 4), at = c(x_seq, y_seq, y_seq)) %>%
+  vplot <- axis(vplot, side = 1, at = x_seq) %>%
+    axis(side=c(2,4), at = y_seq) %>% 
     view(side = 2, ylim = ylims)
   
   return(vplot)

--- a/R/vdiagram-render.R
+++ b/R/vdiagram-render.R
@@ -48,11 +48,6 @@ renderVDiagram <- function(reportObject) {
   y_seq <- pretty(ylims, shrink.sml = 20)
   x_seq <- pretty(xlims, shrink.sml = 20)
   
-  vplot <-
-    do.call(abline, append(list(object = vplot, h = y_seq), styles$ablines))
-  vplot <-
-    do.call(abline, append(list(object = vplot, v = x_seq), styles$ablines))
-  
   vplot <- axis(vplot, side = 1, at = x_seq) %>%
     axis(side=c(2,4), at = y_seq) %>% 
     view(side = 2, ylim = ylims)

--- a/R/vdiagram-styles.R
+++ b/R/vdiagram-styles.R
@@ -4,8 +4,6 @@ getVDiagramStyle <- function() {
       maxStageLine=list(b=0, labels="", col = 'red', lwd = 3, legend.name="Max gage height for the period shown"),
       minStageLine=list(b=0, labels="", col = 'red', lwd = 3, legend.name="Min gage height for the period shown"),
       grid=list(lty = "dotted"),
-      ablines=list(lty = "dotted"),
-      abline_dark = list(col='gray82',lwd=1),
       err_lines=list(angle=90, lwd=1.25, code=3, col = 'black', length=0.1),
       err_points=list(pch = 21, bg = 'white', legend.name="Historical measurements from the last 2 years"),
       err_lines_historic=list(angle=90, lwd=1.25, code=3, col = 'blue', length=0.05),

--- a/man/dvhydrograph.Rd
+++ b/man/dvhydrograph.Rd
@@ -25,6 +25,7 @@ library(jsonlite)
 library(lubridate)
 library(dplyr)
 Sys.setenv(TZ = "UTC")
-reportObject <- fromJSON(system.file('extdata','testsnippets','test-dvhydrograph.json', package = 'repgen'))[['allStats']]
+reportObject <- fromJSON(system.file('extdata','testsnippets', 'test-dvhydrograph.json', 
+                                     package = 'repgen'))[['allStats']]
 dvhydrograph(reportObject, 'Author Name')
 }

--- a/man/hasReferenceSeries.Rd
+++ b/man/hasReferenceSeries.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/uvhydrograph-data.R
 \name{hasReferenceSeries}
 \alias{hasReferenceSeries}
-\title{Has Refernce Series
+\title{Has Reference Series
 Determines if the report has a reference series attached}
 \usage{
 hasReferenceSeries(reportObject)
@@ -14,6 +14,6 @@ hasReferenceSeries(reportObject)
 true/false
 }
 \description{
-Has Refernce Series
+Has Reference Series
 Determines if the report has a reference series attached
 }

--- a/tests/testthat/test-uvhydrograph-render.R
+++ b/tests/testthat/test-uvhydrograph-render.R
@@ -324,9 +324,7 @@ test_that("createPrimaryPlot correctly configured gsplot",{
   expect_equal(plot_object[['global']][['title']][['xlab']], "UV Series: 2016-05-02 17:00:00 through 2016-05-23 17:45:00") 
   
   expect_is(plot_object[['view.1.2']], "list")
-  expect_equal(length(plot_object[['view.1.2']]), 31) #all plot calls are there (this will
-  # be 27 when using a gsplot version >= 0.7.2 because error_bar persists through final
-  # gsplot object. So x & y arrows will be still be listed as a single error_bar call)
+  expect_equal(length(plot_object[['view.1.2']]), 27) #all plot calls are there 
   
   #do not exclude negatives
   plot_object <- repgen:::createPrimaryPlot(
@@ -360,9 +358,7 @@ test_that("createPrimaryPlot correctly configured gsplot",{
   expect_equal(plot_object[['global']][['title']][['xlab']], "UV Series: 2016-05-02 17:00:00 through 2016-05-23 17:45:00") 
   
   expect_is(plot_object[['view.1.2']], "list")
-  expect_equal(length(plot_object[['view.1.2']]), 31) #all plot calls are there (this will
-  # be 27 when using a gsplot version >= 0.7.2 because error_bar persists through final
-  # gsplot object. So x & y arrows will be still be listed as a single error_bar call)
+  expect_equal(length(plot_object[['view.1.2']]), 27) #all plot calls are there 
 })
 
 test_that("createSecondaryPlot only can handle minimal requirements (just corrected series)",{
@@ -510,10 +506,10 @@ test_that("createSecondaryPlot more tests",{
   expect_equal(plot_object[['global']][['title']][['xlab']], "UV Series: 2016-05-03 17:00:00 through 2016-05-23 17:45:00")
   
   expect_is(plot_object[['view.1.2']], "list")
-  expect_equal(length(plot_object[['view.1.2']]), 20) #all plot calls are there
+  expect_equal(length(plot_object[['view.1.2']]), 17) #all plot calls are there
   
   expect_is(plot_object[['view.1.4']], "list")
-  expect_equal(length(plot_object[['view.1.4']]), 7) #all plot calls are there
+  expect_equal(length(plot_object[['view.1.4']]), 6) #all plot calls are there
   
   expect_is(plot_object[['view.7.2']], "list")
   expect_equal(length(plot_object[['view.7.2']]), 6) #all plot calls are there


### PR DESCRIPTION
NOT `v0.8.0`, just `0.8.0`. Messed up first release, so had to rename.

Actual work to update to the new version:
- fix tests that count the elements in a view because `error_bar` is now passed all the way through so there were 2 arrow calls for what is now 1 error bar 
- fixed how `vdiagram` axes were added. It was incorrectly grouping them all which causes each side to have the same ticks (e.g. `gsplot() %>% points(1:4,1:4) %>% axis( side = c(1, 2, 4), at = c(1:2, 2:4, 1:2))` sets sides 1,2, and 4 ticks to the vector `1 2 2 3 4 1 2`)
- adjusted how to add axis labels to the more accepted gsplot way
- removed unneccessary ablines (grid adds those, so abline was a duplicate) AND removed the unused abline styles
- updated the gsplot version used in `.travis.yml`

There are a few things that I changed along with this PR that bothered me during the `Check`:
- eliminated notes about "missing global variables" (changes to `extremes-data.R` and `utils-read.R`)
- eliminated notes about a code line that was too long (see `sig-dvhydrograph.R`)
- eliminated notes about using `::` vs `:::` (see `utils-read.R` -- @zmoore-usgs `:::` are used when the function is not exported from the package)

I also corrected a typo that has been bothering me (changes to `dvhydrograph-render.R` and `uvhydrograph-data.R`). 