### PR TITLE
AQCU-1053: Fixed an issue where points read from readEstimatedTimeSeries…

### DIFF
--- a/R/correctionsataglance-render.R
+++ b/R/correctionsataglance-render.R
@@ -55,7 +55,7 @@ correctionsataglanceReport <- function(reportObject) {
             y = 115, bty = 'n')
   
   if(!hasValidDataToPlot(dataLanes)){
-    return('The requested dataest is empty or blank.')
+    return(list(timeline = 'The requested dataest is empty or blank.'))
   }
 
   #approvals at top bar

--- a/R/utils-read.R
+++ b/R/utils-read.R
@@ -565,6 +565,9 @@ readTimeSeries <- function(reportObject, seriesName, timezone, descriptionField=
   } else {
     seriesData[['isDV']] <- FALSE
   }
+  
+  #Sort points by time
+  seriesData[['points']] <- seriesData[['points']] %>% arrange(time)
 
   return(seriesData)
 }
@@ -597,6 +600,9 @@ readEstimatedTimeSeries <- function(reportObject, seriesName, timezone, descript
     
     time <- NULL #only here to remove check warnings
     
+    #Sort estimated periods
+    estimatedPeriods <- estimatedPeriods %>% arrange(start)
+    
     #Extract only data in estimated periods
     if(nrow(estimatedPeriods) > 0){
       for(i in 1:nrow(estimatedPeriods)) {
@@ -606,6 +612,7 @@ readEstimatedTimeSeries <- function(reportObject, seriesName, timezone, descript
         estimatedSubset <- rbind(estimatedSubset, subset(seriesData[['points']], (time >= startTime) & (time < endTime)))
       }
     }
+    
     #Replace data with only saved data
     if(inverted){
       nonEstimatedSubset <- subset(seriesData[['points']], !(time %in% estimatedSubset[['time']]))
@@ -619,6 +626,9 @@ readEstimatedTimeSeries <- function(reportObject, seriesName, timezone, descript
       seriesData[['points']] <- stats::na.omit(data.frame(time=as.POSIXct(NA), value=as.character(NA), month=as.character(NA)))
     }
   }
+  
+  #Sort points by time
+  seriesData[['points']] <- seriesData[['points']] %>% arrange(time)
 
   return(seriesData)
 }

--- a/tests/testthat/test-correctionsataglance.R
+++ b/tests/testthat/test-correctionsataglance.R
@@ -1396,8 +1396,8 @@ test_that("correctionsataglanceReport properly constructs a full CORR", {
   expect_error(repgen:::correctionsataglanceReport(reportObject4), "Data for: ' primarySeries ' was not found in report JSON.")
 
   expect_is(corrData1, 'list')
-  expect_is(corrData2, 'character')
-  expect_equal(corrData2, 'The requested dataest is empty or blank.')
+  expect_is(corrData2, 'list')
+  expect_equal(corrData2$timeline, 'The requested dataest is empty or blank.')
   expect_is(corrData3, 'list')
 
   expect_equal(corrData3$tableOfLabels, NULL)


### PR DESCRIPTION
…were sometimes not sorted in ascending order. Fixed an issue found while testing where CORR reports would error when provided empty JSON. Updated CORR report tests.