### PR TITLE
AQCU-1126: Add Processor Images for derivation chain

### DIFF
--- a/inst/templates/derivationchain/body.mustache
+++ b/inst/templates/derivationchain/body.mustache
@@ -1,5 +1,6 @@
 <div id="cy"></div>
 <br/>
+<p><i>Time-Series processor icon images courtesy of Aquatic Informatics.</i></p>
 <span>Showing derivation chain for period:</span><div id="zoomContainer">Zoom Level: <span id="zoomLevel"></span>%</br><button onclick="cy.reset()">Center</button></div><br/>
 <div id="dateSelector" class="btn-group-vertical"  data-toggle-name="selectedPeriod" data-toggle="buttons">
 </div>

--- a/inst/templates/derivationchain/custom.js
+++ b/inst/templates/derivationchain/custom.js
@@ -281,7 +281,7 @@ var makeDerivationCurve = function(forDateString) {
 						{ display: "Computation", value: n.data('computation')  },
 						{ display: "Processor", value: n.data('processorType') },
 						{ display: "Publish", value: n.data('publish')  },
-						{ display: "Primary", value: n.data('primary')  },
+						{ display: "Primary", value: n.data('primary')  }
 						].map(function( link ){
 							return '<span>' + link.display + ' : ' + link.value + '</span>';
 						}).join('<br />\n'),

--- a/inst/templates/derivationchain/custom.js
+++ b/inst/templates/derivationchain/custom.js
@@ -47,18 +47,44 @@ var getTimePeriodEdges = function(nodes) {
 	dateList.sort();
 	
 	return dateList;
-}
+};
 
-var makeNode = function(nodeData, insertedNodes) {
-	
-	var col = colorMap[nodeData.timeSeriesType || "default"];
-	var shape = shapeMap[nodeData.timeSeriesType || "default"];
-
-	var label = nodeData.identifier
+var makeNode = function(nodeList, nodeData, insertedNodes) {
+  
+  var label = nodeData.identifier;
 	if(label) {
-		label = label.split("@")[0]
+		label = label.split("@")[0];
 	}
 	
+	for(var i = 0; i < nodeData.inputTimeSeriesUniqueIds.length; i++) {
+
+	  var col = colorMap[nodeData.timeSeriesType || "default"];
+	  var shape = shapeMap[nodeData.timeSeriesType || "default"];
+	  var node = { 
+	    data: { 
+  	    id: nodeData.uniqueId, 
+  			name: label, 
+  			parameter: nodeData.parameter,
+  			sublocation: nodeData.sublocation,
+  			timeSeriesType: nodeData.timeSeriesType,
+  			computation: nodeData.computation,
+  			processorType: nodeData.processorType,
+  			publish: nodeData.publish,
+  			primary: nodeData.primary,
+  			weight:50,
+  			faveColor: col, 
+  			faveShape: shape 
+	    } 
+	  };
+	  
+	  var nodeProcessorType = processorMap[nodeData.processorType];
+	  if(nodeProcessorType){
+	    node.classes = nodeProcessorType;
+	  }
+	  nodeList.push(node);
+	  
+	}
+
 	insertedNodes[nodeData.uniqueId] = true;
 	
 	return { 
@@ -74,8 +100,8 @@ var makeNode = function(nodeData, insertedNodes) {
 			primary: nodeData.primary,
 			weight: 50, 
 			faveColor: col, 
-			faveShape: shape } }
-}
+			faveShape: shape } };
+};
 
 var insertEdges = function(edgeList, nodeData, traversedEdgeMap, insertedNodes) {
 	
@@ -121,9 +147,9 @@ var makeDerivationCurve = function(forDateString) {
 	var insertedNodes = {};
 	
 	for(var i = 0; i < derivations.length; i++) {
-		var n = derivations[i]
+		var n = derivations[i];
 		if(nodeIncludesDate(n, forDateString)) {
-			nodes.push(makeNode(n, insertedNodes))
+			makeNode(nodes, n, insertedNodes);
 		}
 	}
 	
@@ -159,13 +185,51 @@ var makeDerivationCurve = function(forDateString) {
 			'text-valign': 'center',
 			'text-outline-width': 2,
 			'text-outline-color': 'data(faveColor)',
-			'background-color': 'data(faveColor)',
-			'color': '#fff'
+			'text-wrap': 'wrap',
+			'text-max-width': '200px',
+			'background-color': '#fff',
+			'background-fit': 'cover',
+			'color': '#fff',
+			'border-width': 2,
+			'border-color': '#333',
+			'font-size': 10
+		})
+		.selector('node.ratingModel')
+		.css({
+		  'background-image': 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAQVJREFUeNq0kt0NgjAUhYvps2EE2IARcAM3EF+Mb8gE6gToG/FFNgAngBHqBoxAXABP4dZUpERivMnJSX++tvfeMvZjWFM2zy/MgSlVjw0r+ReQBwshn0AVpRQfASWwJ9AY3ADHsN3AUgUJ6E7+XgOANqyAPG26hnLojJyFsYgGWIIRwKodJc2S1gXbWjnGgX5A0ct3DTAlUEKZqr7uM4IPRriLjFJxcbMLP6qOcOptqG2OejAjoARc9eaYhQOu8ED1FvBiyufiGtze/rGjyz+mkSxepBV0xelHyfzzoTYhbK0+N4A+dUJ+spTLJ1Md6pGXCroo1uZOr9eMRtI4kM3+FU8BBgBg1FIcIRmAgwAAAABJRU5ErkJggg==")'
+		})
+		.selector('node.calculation')
+		.css({
+		  'background-image': 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAT1JREFUeNpiZACC/zONDYDUeiBWYEAFB6C0A5r4AyAOZEw/e4ERqnk/EAswYAJcBoDAByB2ZAIS9XDNlsUMDGq+DEQCkJ56FiBhAOYapwE9ALRIRA0ifWszqnKQwbySEPbn5zB5Axa4v6WMGRjYeUAMBgZhNUz7QGIww9/cgokqgMLgP1yR70wGhmdnGRjOziImDMCABYW3OZ2BVMCCZAs2cIEYA/CCSTwtBA1wIMKlRIQBLP5BoQ2Kore3UBRqKkkz8HFzgtmfvn5nuH7vKZjNhGoPME2p+5AUiEzQdA2x+ddnBgY2XmCCkcJQKCrIxyAjLgTGIDYsT7BAQ1oB7GwQBmkGpQU0AHLyPTaIj3/++gOPJZBIIziQ3t6C5Ac0v8PA6/efsGWmRiZQlgTlKrhXiAMgtY750Z4XAAIMAC2LUPlNin0qAAAAAElFTkSuQmCC")'
+		})
+		.selector('node.correctedpassthrough')
+		.css({
+		  'background-image': 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAP1JREFUeNpidHFx+c9AAtizZw8jMp8FShcC8QUCeg2AuB9dEGbABaDJB/DpBroUqzgTModvFoMDEAuQ4iUWLGL9QNtAXqoH4gIsLvmPz4APQJxwKmwPw6c0hkRo2MBcJwAU+4BuGIoXgApAAfkAZAhQw3qYd0Bew+YajDCAgkYoHQDE94GaG4B0PBDnYwsfDAPMVoFDewGUKwANiwQkNkEXzIf6fwIWuQKgKxSwBaIBejwDDSkEKt4IMhCIFZAC2QAaTiguAKWw/VCMbAhy4gJ5SxEotgHFBehpGzmeoc4FGdII1PiA2ISE7AKQpkR8apgYKAQsODIO0VkcIMAA+QNIBuP+5PMAAAAASUVORK5CYII=")'
+		})
+		.selector('node.statDerived')
+		.css({
+		  'background-image': 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAANtJREFUeNpiYBhowEi0yhn/BYBkPRAXIAsz4dGQAMT7gdgAzM9g/AAkDwLxB8IuAGlmYJgP5T0AYkMgDkASg4krMBHQDAIKQHweWUyK92wj1NALTAQ0IxsCBkqCeyb4qKfnQ73kyIRH8wWg4kQ0Pye6KFeA1AnAwoUJl+ZYffcHQMX9IFtAhnCyvt0A1LAArhkeC1g0gzQBNQSAFWcwXgAaVAg0UAFbeDNhsxnqPwYkf4PUGOAy4AKyZqjNRAMWqB8NgLYe4Dxj/J/UpMwCde4BcvMC04DnRoAAAwD3tktTisqW9AAAAABJRU5ErkJggg==")'
+		})
+		.selector('node.basic')
+		.css({
+		  'background-image': 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAJtJREFUeNpi/P//PwMlgJFSA5jS09MpMoGJZCfPZEgA4v9AvIBkA0CagdR8KDeeJAPQNINAIohgwaMYhC/8T2cowKYZKL4AqwFoiu2BfAMQjU0zhhew2MSATzOKAVg0NwLxR3ya0b2QgK4YaOgGIDsAGhYbsIUXsgEw0xfAbALSF0Ca8cZOWloaKCU6kpsSYS7YP2CZiWIDAAIMACrvPcolLgvaAAAAAElFTkSuQmCC")'
+		})
+		.selector('node.external')
+		.css({
+		  'background-image': 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAMxJREFUeNpi/P//PwMuwNhyUwBITQDiAKiQw/8a9QsoanAZANSsAKRAivmB+CM2zSDAkp6ejs2EjQyyRQJQzSCwAKQZqBZkgD5M0cyZMxmZcLj+ABDbI/E3ADULIGuGg7S0tP8gb6BjhuYb/5GwALo8TB8TAxEA6PwPuORYsIS6AZYAdYAyP6AHJBMWmxKAeD+aGSD+BmwuYMLiXJABC9GEcUYjEw4/IxuCUzNOA5AMmYhPM0YgYjGkgFAMERWNg9sAcBjgyFBEAYAAAwCnnW4L0Lh2iwAAAABJRU5ErkJggg==")'
+		})
+		.selector('node.fillMissingDate')
+		.css({
+		  'background-image': 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAPpJREFUeNpiZGi+7sDAwFAPxA8YajUTGUgETEDsAMUJQMMUyDFgAhB/gPLrSTegVhOkeSKUT7IrmKA0QVeknTEOwG0Aca5YDzRkPxAbYHMBA5FhAQrs80BD5gOxAEiAEUW6+XoDSDMv5xsGYb6HDJaaSxh4OV/j8j7IskIWZJH/nppw9i0GXoYFDAoMbxnYcBlwAYgPwF3w/wwDyEn3gVjgCQPnhmYGrYloGvZD6QdAnDjL5OwBFFmgAQ1A/B+KFbDEwnsgLsDqFpDtQPweqnk+jmgUwJkYCNmOFxBjO6GUCPIXzHmNpBoAikZQaNqDQpfRBBzCJAGAAAMAN2JnMVIyij8AAAAASUVORK5CYII=")'
+		})
+		.selector('node.conditionalFill')
+		.css({
+		  'background-image': 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAPpJREFUeNpiZGi+7sDAwFAPxA8YajUTGUgETEDsAMUJQMMUyDFgAhB/gPLrSTegVhOkeSKUT7IrmKA0QVeknTEOwG0Aca5YDzRkPxAbYHMBA5FhAQrs80BD5gOxAEiAEUW6+XoDSDMv5xsGYb6HDJaaSxh4OV/j8j7IskIWZJH/nppw9i0GXoYFDAoMbxnYcBlwAYgPwF3w/wwDyEn3gVjgCQPnhmYGrYloGvZD6QdAnDjL5OwBFFmgAQ1A/B+KFbDEwnsgLsDqFpDtQPweqnk+jmgUwJkYCNmOFxBjO6GUCPIXzHmNpBoAikZQaNqDQpfRBBzCJAGAAAMAN2JnMVIyij8AAAAASUVORK5CYII=")'
 		})
 		.selector(':selected')
 		.css({
-			'border-width': 3,
-			'border-color': '#333'
+			'border-width': 2,
+			'border-color': '#dd0000'
 		})
 		.selector('edge')
 		.css({
@@ -181,29 +245,25 @@ var makeDerivationCurve = function(forDateString) {
 		.selector('edge.ratingModel')
 		.css({
 			'line-style': 'solid',
-			'target-arrow-shape': 'triangle'
 		})
 		.selector('edge.calculation')
 		.css({
 			'line-style': 'solid',
-			'target-arrow-shape': 'tee'
 		})
 		.selector('edge.correctedpassthrough')
 		.css({
 			'line-style': 'solid',
-			'target-arrow-shape': 'triangle-cross'
 		})
 		.selector('edge.statDerived')
 		.css({
 			'line-style': 'dotted',
-			'target-arrow-shape': 'diamond'
 		})
 		.selector('.faded')
 		.css({
 			'opacity': 0.25,
 			'text-opacity': 0
 		}),
-	
+		
 		elements: {
 			nodes: nodes,
 			edges: edges
@@ -219,9 +279,9 @@ var makeDerivationCurve = function(forDateString) {
 						{ display: "Sublocation", value: n.data('sublocation')  },
 						{ display: "Type", value: n.data('timeSeriesType')  },
 						{ display: "Computation", value: n.data('computation')  },
-						{ display: "Processor", value: n.data('processorType')  },
+						{ display: "Processor", value: n.data('processorType') },
 						{ display: "Publish", value: n.data('publish')  },
-						{ display: "Primary", value: n.data('primary')  }
+						{ display: "Primary", value: n.data('primary')  },
 						].map(function( link ){
 							return '<span>' + link.display + ' : ' + link.value + '</span>';
 						}).join('<br />\n'),
@@ -233,7 +293,7 @@ var makeDerivationCurve = function(forDateString) {
 							classes: 'qtip-bootstrap',
 							tip: {
 								width: 16,
-								height: 8
+								height: 8,
 							}
 						}
 				});


### PR DESCRIPTION
Adjusted the makNode to add the processor names as classes, which allows us to add background images as Data-URI's in the Cytoscape js CSS area.

Added the footnote for where we got the images right below the canvas.

Was only working with ratingModel, statDerived, calculation, correctedpassthrough in the example, I was given, but saw that there were more images in the ticket than that.  So I added Basic,  External, Fill missing data, and Conditional fill background images into the code, so when they are needed they should be accessible to the code right away. Fingers crossed at least.