### PR TITLE
updating anyDataExist to handle empty list items

### DIFF
--- a/R/utils-plot.R
+++ b/R/utils-plot.R
@@ -217,9 +217,7 @@ plotTimeSeries <- function(plot_object, ts, name, timezone, configFunction, conf
 #' @param configFunctionParams list of params to call pall configFunctionWith
 #' @param isDV Whether or not the plot is a daily value plot (defulat: FALSE)
 plotItem <- function(plot_object, item, configFunction, configFunctionParams, isDV=FALSE){
-  #if item has list elements that are empty, filter them out to avoid error
-  item <- Filter(length, item)
-  
+
   if(!is.null(item) && anyDataExist(item)){
     plotItem <- do.call(configFunction, configFunctionParams)
     

--- a/R/utils-validation.R
+++ b/R/utils-validation.R
@@ -91,6 +91,9 @@ validParam <- function(val, param, required = FALSE, as.numeric = FALSE){
 #if absolutely no data comes back after parsing - skip to render with a message
 anyDataExist <- function(data){
   emptyData <- any(c(length(data) == 0, nrow(data) == 0, is.null(data)))
+  if(is.list(data) && !emptyData){
+    emptyData <- !any(unlist(lapply(data, anyDataExist)))
+  }
   notEmptyData <- !emptyData
   return(notEmptyData)
 }

--- a/tests/testthat/test-utils-plot.R
+++ b/tests/testthat/test-utils-plot.R
@@ -139,6 +139,39 @@ test_that('plotItem properly adds an item to a GSPlot object with the proper sty
     expect_equal(length(plot_object$view.1.2$points$y), 2)
 })
 
+test_that('plotItem does not fail with an empty list', {
+  
+  timezone <- "Etc/GMT+5"
+  startDate <- repgen:::flexibleTimeParse("2013-11-10T12:00:00-05:00", timezone)
+  endDate <- repgen:::flexibleTimeParse("2013-12-02T23:59:00-05:00", timezone)
+  
+  plotDates <- c(
+    as.Date("2013-11-10T00:00:00-05:00"),
+    as.Date("2013-11-17T00:00:00-05:00"),
+    as.Date("2013-11-24T00:00:00-05:00"),
+    as.Date("2013-12-01T00:00:00-05:00")
+  )
+  
+  item <- list(time = character(), 
+               value = numeric(),
+               month = character(),
+               legend.name = character())
+  
+  plot_object <- gsplot(ylog = FALSE, yaxs = 'i') %>%
+    grid(nx = 0, ny = NULL, equilogs = FALSE, lty = 3, col = "gray") %>%
+    axis(1, at = plotDates, labels = format(plotDates, "%b\n%d"), padj = 0.5) %>%
+    axis(2, reverse = FALSE, las=0) %>%
+    view(xlim = c(startDate, endDate))
+  
+  plot_items_view12_before <- length(plot_object$view.1.2)
+  plot_object <- repgen:::plotItem(plot_object, item, repgen:::getDVHydrographPlotConfig, 
+                                   list(pts, 'groundWaterLevels'), isDV=TRUE)
+  plot_items_view12_after <- length(plot_object$view.1.2)
+  
+  expect_equal(plot_items_view12_before, plot_items_view12_after)
+  
+})
+
 test_that('plotTimeSeries properly adds a time series to a GSPlot object with the proper styles', {
     timezone <- "Etc/GMT+5"
     startDate <- repgen:::flexibleTimeParse("2013-11-10T12:00:00-05:00", timezone)

--- a/tests/testthat/test-utils-validation.R
+++ b/tests/testthat/test-utils-validation.R
@@ -159,6 +159,7 @@ test_that('anyDataExist works for lists', {
   expect_false(repgen:::anyDataExist(list()))
   expect_false(repgen:::anyDataExist(list(one=numeric(), two=numeric())))
   expect_true(repgen:::anyDataExist(list(one=c(1:3), two="one")))
+  expect_true(repgen:::anyDataExist(list(one=c(), two="one")))
 })
 
 test_that('anyDataExist works for vectors', {

--- a/tests/testthat/test-utils-validation.R
+++ b/tests/testthat/test-utils-validation.R
@@ -155,6 +155,25 @@ test_that('validParam returns empty string if NULL and not required and not as.n
   expect_equal(repgen:::validParam(val1, "testParam", FALSE, FALSE), "")
 })
 
+test_that('anyDataExist works for lists', {
+  expect_false(repgen:::anyDataExist(list()))
+  expect_false(repgen:::anyDataExist(list(one=numeric(), two=numeric())))
+  expect_true(repgen:::anyDataExist(list(one=c(1:3), two="one")))
+})
+
+test_that('anyDataExist works for vectors', {
+  expect_false(repgen:::anyDataExist(c()))
+  expect_true(repgen:::anyDataExist(1:4))
+  expect_true(repgen:::anyDataExist(c("one", "two")))
+})
+
+test_that('anyDataExist works for data.frames', {
+  expect_false(repgen:::anyDataExist(data.frame()))
+  expect_false(repgen:::anyDataExist(data.frame(one=numeric(), two=numeric())))
+  expect_true(repgen:::anyDataExist(data.frame(one=c(1:3))))
+  expect_true(repgen:::anyDataExist(data.frame(one=c(1:2), two=c("row1", "row2"))))
+})
+
 test_that('checkRequiredFields properly checks fields', {
   library(jsonlite)
 


### PR DESCRIPTION
anyDataExist now returns FALSE when given:

```r
list(one=c(), 
     two=numeric())
```

This is a more robust implementation to fix AQCU-1136 (#670)