### PR TITLE
AQCU-1126: Icon associated with transformation processorType

### DIFF
--- a/inst/templates/derivationchain/custom.js
+++ b/inst/templates/derivationchain/custom.js
@@ -33,7 +33,8 @@ var processorMap = {
 		"correctedpassthrough" : "correctedpassthrough",
 		"fillmissingdata": "fillmissingdata",
     "conditionalfill": "conditionaldata",
-    "datumconversion": "datumconversion"
+    "datumconversion": "datumconversion",
+    "transformation": "transformation"
 };
 
 var getTimePeriodEdges = function(nodes) {
@@ -251,6 +252,10 @@ var makeDerivationCurve = function(forDateString) {
 		  'background-image': 'url("data:image/jpeg;base64,' + correctedPassThroughImage + '")'
 		})
 		.selector('node.statDerived')
+		.css({
+		  'background-image': 'url("data:image/jpeg;base64,' + statsImage + '")'
+		})
+		.selector('node.transformation')
 		.css({
 		  'background-image': 'url("data:image/jpeg;base64,' + statsImage + '")'
 		})


### PR DESCRIPTION
After talking to Laura it was found out that the processorType is associated with the stat derived icon.  I created the connection in the code and it should be displayed whenever transformation is around.