### PR TITLE
AQCU-1146: for templated reports where they do not have startDate or …

### DIFF
--- a/R/utils-render.R
+++ b/R/utils-render.R
@@ -112,8 +112,9 @@ startTemplatedRender <- function(reportJson, author){
   
   #adding appropriately formatted start and end dates to reportJSON
   if (anyDataExist(reportJson[['reportMetadata']][['startDate']]) && anyDataExist(reportJson[['reportMetadata']][['endDate']])) {
-    templateData[['reportMetadata']][['displayStartDate']] <- format(as.Date(fetchReportMetadataField(reportJson,'startDate')), "%Y-%m-%d")
-    templateData[['reportMetadata']][['displayEndDate']] <- format(as.Date(fetchReportMetadataField(reportJson,'endDate')), "%Y-%m-%d")
+    templateData[['reportMetadata']][['periodDisplay']] <- paste(format(as.Date(fetchReportMetadataField(reportJson,'startDate')), "%Y-%m-%d")," to ", format(as.Date(fetchReportMetadataField(reportJson,'endDate')), "%Y-%m-%d"))
+  } else {
+    templateData[['reportMetadata']][['periodDisplay']] <- "Dynamic based on selection"
   }
   
   #call custom data parsing, this will allow reports to specify the data structure they want available to the templates

--- a/inst/templates/common/header.mustache
+++ b/inst/templates/common/header.mustache
@@ -22,7 +22,7 @@
 {{#reportMetadata.comparisonSeries}}<strong>Comparison Time Series:</strong> {{reportMetadata.comparisonSeries}}{{/reportMetadata.comparisonSeries}}
 </div>
 <div class="header-col-right">
-<p><strong>Period:</strong> {{reportMetadata.displayStartDate}} to {{reportMetadata.displayEndDate}}</p>
+<p><strong>Period:</strong> {{reportMetadata.periodDisplay}}</p>
 {{#reportMetadata.firstReferenceTimeSeriesLabel}}<p><strong>Reference Time Series 1:</strong> {{reportMetadata.firstReferenceTimeSeriesLabel}}</p>{{/reportMetadata.firstReferenceTimeSeriesLabel}}
 {{#reportMetadata.secondReferenceTimeSeriesLabel}}<p><strong>Reference Time Series 2:</strong> {{reportMetadata.secondReferenceTimeSeriesLabel}}</p>{{/reportMetadata.secondReferenceTimeSeriesLabel}}
 {{#reportMetadata.thirdReferenceTimeSeriesLabel}}<p><strong>Reference Time Series 3:</strong> {{reportMetadata.thirdReferenceTimeSeriesLabel}}</p>{{/reportMetadata.thirdReferenceTimeSeriesLabel}}


### PR DESCRIPTION
…endDate in their reportMetadata, display "Period: Dynamic based on selection" instead of "Period: 2016-05-01 to 2017-05-30" for example