### PR TITLE
AQCU-1176: UV Hydro: Estimated corrected values are not plotting

### DIFF
--- a/R/uvhydrograph-data.R
+++ b/R/uvhydrograph-data.R
@@ -113,7 +113,7 @@ parseUvEstimatedSeries <- function(reportObject, seriesName, month, timezone) {
 #' @param timezone timezone to parse all data into
 #' @return named list of timeseries objects (NULL if not in report object) as well as inverted and loggedAxis flags. loggedAxis is set so that all series are supported on the same axis.
 parsePrimarySeriesList <- function(reportObject, month, timezone) {
-  correctedSeries <- readNonEstimatedTimeSeries(reportObject, "primarySeries", timezone, onlyMonth=month)
+  correctedSeries <- readTimeSeries(reportObject, "primarySeries", timezone, onlyMonth=month)
   estimatedSeries <- readEstimatedTimeSeries(reportObject, "primarySeries", timezone, onlyMonth=month)
   uncorrectedSeries <- readTimeSeries(reportObject, "primarySeriesRaw", timezone, onlyMonth=month)
   


### PR DESCRIPTION
called readTimeSeries for primarySeries (corrected TS) instead of
filtering by non-estimated points.