### PR TITLE
AQCU-1178: changes to how we log axes

### DIFF
--- a/R/dvhydrograph-render.R
+++ b/R/dvhydrograph-render.R
@@ -104,11 +104,11 @@ createDVHydrographPlot <- function(reportObject){
   
 
   #Create Base Plot Object
-  plot_object <- gsplot(ylog = logAxis, yaxs = 'i') %>%
+  plot_object <- gsplot(yaxs = 'i') %>%
       grid(nx = 0, ny = NULL, equilogs = FALSE, lty = 3, col = "gray") %>%
       axis(1, at = plotDates, labels = format(plotDates, "%b\n%d"), padj = 0.5) %>%
       axis(2, reverse = invertedFlag, las=0) %>%
-      view(xlim = c(startDate, endDate))
+      view(xlim = c(startDate, endDate), log=ifelse(logAxis, 'y', ''))
     
   plot_object <-
     XAxisLabelStyle(plot_object, startDate, endDate, timezone, plotDates)
@@ -218,10 +218,10 @@ createDVHydrographRefPlot <- function(reportObject, series, descriptions) {
   approvals <- readApprovalBar(referenceSeries, timezone, legend_nm=referenceSeries[['legend.name']], snapToDayBoundaries=TRUE)
 
   #Do Plotting
-  plot_object <- gsplot(ylog = logAxis, yaxs = 'i') %>%
+  plot_object <- gsplot(yaxs = 'i') %>%
     grid(nx = NA, ny = NULL, lty = 3, col = "gray") %>%
     axis(2, reverse = invertedFlag, las=0) %>%
-    view(xlim = c(startDate, endDate)) %>%
+    view(xlim = c(startDate, endDate), log=ifelse(logAxis, 'y', '')) %>%
     title(main = paste("\n\n", "Reference Time Series", series_number))
   
   plot_object <-

--- a/R/fiveyeargwsum-render.R
+++ b/R/fiveyeargwsum-render.R
@@ -86,9 +86,9 @@ createfiveyeargwsumPlot <- function(reportObject){
   yLabel <- paste0(priorityTS[['type']], ", ", priorityTS[['units']])
 
   #Create the Base Plot Object
-  plot_object <- gsplot(yaxs = 'i', ylog=logAxis, xaxt = "n", mar = c(8, 4, 4, 2.5) + 0.1) %>%
+  plot_object <- gsplot(yaxs = 'i', xaxt = "n", mar = c(8, 4, 4, 2.5) + 0.1) %>%
       axis(side = 1, at = date_seq_mo, labels = FALSE) %>%
-      view(xlim = c(startDate, endDate)) %>%
+      view(xlim = c(startDate, endDate), log=ifelse(logAxis, 'y', '')) %>%
       axis(side = 2, reverse = invertedFlag, las = 0) %>%
       grid(col = "lightgrey", lty = 1) %>%
       title(ylab = yLabel)

--- a/R/uvhydrograph-render.R
+++ b/R/uvhydrograph-render.R
@@ -164,10 +164,6 @@ createPrimaryPlot <- function(
   
   lims <- calculatePrimaryLims(primarySeriesList, isDischarge)
   
-  logPrimary <- FALSE
-  logRef <- FALSE
-  logComp <- FALSE
-  
   timeInformation <- parseUvTimeInformationFromLims(lims, timezone)
   startDate <- timeInformation[['start']]
   endDate <- timeInformation[['end']]
@@ -203,6 +199,8 @@ createPrimaryPlot <- function(
   }
   
   #corrected data
+  # primary axis is logged based on corrected data; if no corrected data, should be FALSE
+  # gsplot object logged inside of plotTimeSeries >> plotItem
   logPrimary <- isLogged(primarySeriesList[['corrected']][['points']], primarySeriesList[['corrected']][['isVolumetricFlow']], excludeZeroNegativeFlag)
   plot_object <- plotTimeSeries(plot_object, primarySeriesList[['corrected']], "corrected", 
                                 timezone, getPrimaryPlotConfig, list(uvInfo[['label']], limsAndSides$ylims[['primary']], limsAndSides$sides[['primary']]), excludeZeroNegativeFlag)
@@ -331,8 +329,6 @@ createSecondaryPlot <- function(uvInfo, secondarySeriesList,
   
   lims <- calculateLims(secondarySeriesList[['corrected']][['points']])
   
-  doLog <- FALSE
-  
   timeInformation <- parseUvTimeInformationFromLims(lims, timezone)
   startDate <- timeInformation[['start']]
   endDate <- timeInformation[['end']]
@@ -364,6 +360,8 @@ createSecondaryPlot <- function(uvInfo, secondarySeriesList,
   }
   
   #corrected data
+  # primary axis is logged based on corrected data; if no corrected data, should be FALSE
+  # gsplot object logged inside of plotTimeSeries >> plotItem
   doLog <- isLogged(secondarySeriesList[['corrected']][['points']], secondarySeriesList[['corrected']][['isVolumetricFlow']], excludeZeroNegativeFlag)
   plot_object <- plotTimeSeries(plot_object, secondarySeriesList[['corrected']], "corrected", 
       timezone, getSecondaryPlotConfig, list(uvInfo[['label']], lims$ylim), excludeZeroNegativeFlag)
@@ -420,7 +418,6 @@ createSecondaryPlot <- function(uvInfo, secondarySeriesList,
   plot_object <- addToGsplot(plot_object, getCorrectionsPlotConfig(corrections, startDate, endDate, 
           uvInfo[['label']], lims))
   
-  # assuming ylog=FALSE because there does not appear to be any way to log side 2 in this function
   plot_object <- addToGsplot(plot_object, getApprovalBarConfig(approvals, ylim(plot_object, side = 2), ylog=doLog))
   
   plot_object <- rmDuplicateLegendItems(plot_object)
@@ -569,8 +566,6 @@ getPrimaryPlotConfig <- function(timeseries, name, label,
   }
   
   if(doLog){
-    #ylim[[1]] <- ifelse(ylim[[1]] <= 0, 0.0001, ylim[[1]])
-    #ylim[[2]] <- ifelse(ylim[[2]] <= ylim[[1]], 0.0002, ylim[[2]])
     doLog = 'y'
   } else {
     doLog = ''
@@ -622,8 +617,6 @@ getSecondaryPlotConfig <- function(timeseries, name, legend_label, ylim, doLog=F
   y <- timeseries[['value']]
   
   if(doLog){
-    ylim[[1]] <- ifelse(ylim[[1]] <= 0, 0.0001, ylim[[1]])
-    ylim[[2]] <- ifelse(ylim[[2]] <= ylim[[1]], 0.0002, ylim[[2]])
     doLog = 'y'
   } else {
     doLog = ''

--- a/tests/testthat/test-utils-approvals.R
+++ b/tests/testthat/test-utils-approvals.R
@@ -13,9 +13,9 @@ testSeries <- list(
     stringsAsFactors=FALSE)
 )
 
-plot_object <- gsplot(ylog=logAxis) %>% 
+plot_object <- gsplot() %>% 
   view(xlim = c(as.POSIXct("2016-05-01 00:00:00"), as.POSIXct("2016-05-31 23:59:59")),
-       ylim = c(0,30)) %>% 
+       ylim = c(0,30), log=ifelse(logAxis, 'y', '')) %>% 
   lines(testSeries$time, testSeries$value, reverse = invertedFlag)
 
 approvalBars <- list(

--- a/tests/testthat/test-utils-limits.R
+++ b/tests/testthat/test-utils-limits.R
@@ -95,8 +95,9 @@ test_that("RescaleYTop adds padding to the top of plot", {
   expect_true(ylim(testPlot)[['side.2']][2] > 2)
   
   #standard logged
-  testPlot <- gsplot(ylog=TRUE) %>% 
-      points(c(1,2), c(1,2))
+  testPlot <- gsplot() %>% 
+    view(log='y') %>% 
+    points(c(1,2), c(1,2))
   testPlot <- repgen:::RescaleYTop(testPlot)
   expect_true(ylim(testPlot)[['side.2']][2] > 2)
   
@@ -108,9 +109,10 @@ test_that("RescaleYTop adds padding to the top of plot", {
   expect_true(ylim(testPlot)[['side.2']][2] < 1) #the top of the plot is now 1
   
   #reversed/logged axis
-  testPlot <- gsplot(ylog=TRUE) %>% 
-      axis(side = 2, reverse = TRUE, las = 0) %>% 
-      points(c(2,4), c(2,4))
+  testPlot <- gsplot() %>% 
+    view(log='y') %>% 
+    axis(side = 2, reverse = TRUE, las = 0) %>% 
+    points(c(2,4), c(2,4))
   testPlot <- repgen:::RescaleYTop(testPlot)
   expect_true(ylim(testPlot)[['side.2']][2] < 2) 
 })

--- a/tests/testthat/test-utils-plot.R
+++ b/tests/testthat/test-utils-plot.R
@@ -26,6 +26,7 @@ test_that('formatMinMaxLabel doesnt error for NULL data', {
 
 test_that('XAxisLabelStyle properly creates X Axis labels', {
     timezone <- "Etc/GMT+5"
+    logAxis <- FALSE
     startDate <- repgen:::flexibleTimeParse("2013-11-10T12:00:00-05:00", timezone)
     endDate1 <- repgen:::flexibleTimeParse("2013-12-02T23:59:00-05:00", timezone)
     endDate2 <- repgen:::flexibleTimeParse("2014-11-12T23:59:00-05:00", timezone)
@@ -55,17 +56,19 @@ test_that('XAxisLabelStyle properly creates X Axis labels', {
         as.Date("2014-10-12 GMT+5"), as.Date("2014-10-19 GMT+5"), as.Date("2014-10-26 GMT+5"),
         as.Date("2014-11-02 GMT+5"), as.Date("2014-11-09 GMT+5")
     )
-    plot_object1 <- gsplot(ylog = FALSE, yaxs = 'i') %>%
+    
+    
+    plot_object1 <- gsplot(yaxs = 'i') %>%
       grid(nx = 0, ny = NULL, equilogs = FALSE, lty = 3, col = "gray") %>%
       axis(1, at = plotDates1, labels = format(plotDates1, "%b\n%d"), padj = 0.5) %>%
       axis(2, reverse = FALSE, las=0) %>%
-      view(xlim = c(startDate, endDate1))
+      view(xlim = c(startDate, endDate1), log=ifelse(logAxis, 'y', ''))
 
-    plot_object2 <- gsplot(ylog = FALSE, yaxs = 'i') %>%
+    plot_object2 <- gsplot(yaxs = 'i') %>%
       grid(nx = 0, ny = NULL, equilogs = FALSE, lty = 3, col = "gray") %>%
       axis(1, at = plotDates2, labels = format(plotDates2, "%b\n%d"), padj = 0.5) %>%
       axis(2, reverse = FALSE, las=0) %>%
-      view(xlim = c(startDate, endDate2))
+      view(xlim = c(startDate, endDate2), log=ifelse(logAxis, 'y', ''))
 
     newPlot1 <- repgen:::XAxisLabelStyle(plot_object1, startDate, endDate1, timezone, plotDates1)
     newPlot2 <- repgen:::XAxisLabelStyle(plot_object2, startDate, endDate2, timezone, plotDates2)
@@ -111,6 +114,7 @@ test_that('Calculate Limits properly calculates the limits of the provided data'
 
 test_that('plotItem properly adds an item to a GSPlot object with the proper styles', {
     timezone <- "Etc/GMT+5"
+    logAxis <- FALSE
     startDate <- repgen:::flexibleTimeParse("2013-11-10T12:00:00-05:00", timezone)
     endDate <- repgen:::flexibleTimeParse("2013-12-02T23:59:00-05:00", timezone)
 
@@ -127,11 +131,11 @@ test_that('plotItem properly adds an item to a GSPlot object with the proper sty
         value = c(10, 20)
     )
 
-    plot_object <- gsplot(ylog = FALSE, yaxs = 'i') %>%
+    plot_object <- gsplot(yaxs = 'i') %>%
       grid(nx = 0, ny = NULL, equilogs = FALSE, lty = 3, col = "gray") %>%
       axis(1, at = plotDates, labels = format(plotDates, "%b\n%d"), padj = 0.5) %>%
       axis(2, reverse = FALSE, las=0) %>%
-      view(xlim = c(startDate, endDate))
+      view(xlim = c(startDate, endDate), log=ifelse(logAxis, 'y', ''))
 
     plot_object <- repgen:::plotItem(plot_object, pts, repgen:::getDVHydrographPlotConfig, list(pts, 'groundWaterLevels'), isDV=TRUE)
   
@@ -142,6 +146,7 @@ test_that('plotItem properly adds an item to a GSPlot object with the proper sty
 test_that('plotItem does not fail with an empty list', {
   
   timezone <- "Etc/GMT+5"
+  logAxis <- FALSE
   startDate <- repgen:::flexibleTimeParse("2013-11-10T12:00:00-05:00", timezone)
   endDate <- repgen:::flexibleTimeParse("2013-12-02T23:59:00-05:00", timezone)
   
@@ -157,11 +162,11 @@ test_that('plotItem does not fail with an empty list', {
                month = character(),
                legend.name = character())
   
-  plot_object <- gsplot(ylog = FALSE, yaxs = 'i') %>%
+  plot_object <- gsplot(yaxs = 'i') %>%
     grid(nx = 0, ny = NULL, equilogs = FALSE, lty = 3, col = "gray") %>%
     axis(1, at = plotDates, labels = format(plotDates, "%b\n%d"), padj = 0.5) %>%
     axis(2, reverse = FALSE, las=0) %>%
-    view(xlim = c(startDate, endDate))
+    view(xlim = c(startDate, endDate), log=ifelse(logAxis, 'y', ''))
   
   plot_items_view12_before <- length(plot_object$view.1.2)
   plot_object <- repgen:::plotItem(plot_object, item, repgen:::getDVHydrographPlotConfig, 
@@ -174,6 +179,7 @@ test_that('plotItem does not fail with an empty list', {
 
 test_that('plotTimeSeries properly adds a time series to a GSPlot object with the proper styles', {
     timezone <- "Etc/GMT+5"
+    logAxis <- FALSE
     startDate <- repgen:::flexibleTimeParse("2013-11-10T12:00:00-05:00", timezone)
     endDate <- repgen:::flexibleTimeParse("2013-12-02T23:59:00-05:00", timezone)
 
@@ -194,11 +200,11 @@ test_that('plotTimeSeries properly adds a time series to a GSPlot object with th
         points = pts
     )
 
-    plot_object <- gsplot(ylog = FALSE, yaxs = 'i') %>%
+    plot_object <- gsplot(yaxs = 'i') %>%
       grid(nx = 0, ny = NULL, equilogs = FALSE, lty = 3, col = "gray") %>%
       axis(1, at = plotDates, labels = format(plotDates, "%b\n%d"), padj = 0.5) %>%
       axis(2, reverse = FALSE, las=0) %>%
-      view(xlim = c(startDate, endDate))
+      view(xlim = c(startDate, endDate), log=ifelse(logAxis, 'y', ''))
 
     plot_object <- repgen:::plotTimeSeries(plot_object, timeSeries, 'stat1TimeSeries', timezone, repgen:::getDVHydrographPlotConfig, list(ylabel=""), isDV=TRUE)
   
@@ -287,6 +293,7 @@ test_that('formatTimeSeriesForPlotting doesnt error with NULL time series', {
 
 test_that('delineateYearBoundaries properly creates lines at year boundaries', {
     timezone <- "Etc/GMT+5"
+    logAxis <- FALSE
     startDate <- repgen:::flexibleTimeParse("2013-12-21T12:00:00-05:00", timezone)
     endDate <- repgen:::flexibleTimeParse("2014-01-07T23:59:00-05:00", timezone)
 
@@ -298,11 +305,11 @@ test_that('delineateYearBoundaries properly creates lines at year boundaries', {
 
     years <- c(as.Date("2014-01-01T00:00:00-05:00"))
 
-    plot_object <- gsplot(ylog = FALSE, yaxs = 'i') %>%
+    plot_object <- gsplot(yaxs = 'i') %>%
       grid(nx = 0, ny = NULL, equilogs = FALSE, lty = 3, col = "gray") %>%
       axis(1, at = plotDates, labels = format(plotDates, "%b\n%d"), padj = 0.5) %>%
       axis(2, reverse = FALSE, las=0) %>%
-      view(xlim = c(startDate, endDate))
+      view(xlim = c(startDate, endDate), log=ifelse(logAxis, 'y', ''))
 
     plot_object <- repgen:::DelineateYearBoundaries(plot_object, years)
 
@@ -313,6 +320,7 @@ test_that('delineateYearBoundaries properly creates lines at year boundaries', {
 
 test_that('XAxisLabels adds XAxis Labels to a GSPlot object', {
     timezone <- "Etc/GMT+5"
+    logAxis <- FALSE
     startDate <- repgen:::flexibleTimeParse("2013-12-21T12:00:00-05:00", timezone)
     endDate <- repgen:::flexibleTimeParse("2014-01-07T23:59:00-05:00", timezone)
 
@@ -326,11 +334,11 @@ test_that('XAxisLabels adds XAxis Labels to a GSPlot object', {
     text <- c('J')
     years <- c(as.Date("2014-01-01T00:00:00-05:00"))
 
-    plot_object <- gsplot(ylog = FALSE, yaxs = 'i') %>%
+    plot_object <- gsplot(yaxs = 'i') %>%
       grid(nx = 0, ny = NULL, equilogs = FALSE, lty = 3, col = "gray") %>%
       axis(1, at = plotDates, labels = format(plotDates, "%b\n%d"), padj = 0.5) %>%
       axis(2, reverse = FALSE, las=0) %>%
-      view(xlim = c(startDate, endDate))
+      view(xlim = c(startDate, endDate), log=ifelse(logAxis, 'y', ''))
 
     plot_object <- repgen:::XAxisLabels(plot_object, text, months, years)
 
@@ -360,6 +368,7 @@ test_that('log_tick_marks properly creates logarithmically spaced tick marks bet
 
 test_that('extendYaxisLimits properly extends the limits of the y-Axis', {
     timezone <- "Etc/GMT+5"
+    logAxis <- FALSE
     startDate <- repgen:::flexibleTimeParse("2013-11-10T12:00:00-05:00", timezone)
     endDate <- repgen:::flexibleTimeParse("2013-12-02T23:59:00-05:00", timezone)
 
@@ -380,11 +389,11 @@ test_that('extendYaxisLimits properly extends the limits of the y-Axis', {
         points = pts
     )
 
-    plot_object <- gsplot(ylog = FALSE, yaxs = 'i') %>%
+    plot_object <- gsplot(yaxs = 'i') %>%
       grid(nx = 0, ny = NULL, equilogs = FALSE, lty = 3, col = "gray") %>%
       axis(1, at = plotDates, labels = format(plotDates, "%b\n%d"), padj = 0.5) %>%
       axis(2, reverse = FALSE, las=0) %>%
-      view(xlim = c(startDate, endDate))
+      view(xlim = c(startDate, endDate), log=ifelse(logAxis, 'y', ''))
 
     plot_object <- repgen:::plotTimeSeries(plot_object, timeSeries, 'stat1TimeSeries', timezone, repgen:::getDVHydrographPlotConfig, list(ylabel=""), isDV=TRUE)
 


### PR DESCRIPTION
Plot axes were not properly set up for logging (`gsplot(ylog=TRUE)` has no effect) but data was being added as logged. Proper way to log is to use `view(log='y')` when the y axis should be logged and `view(log='')` when the axis should not be logged.

Fixed tests and removed some unused code from #631/#633. 