### PR TITLE
AQCU-1179: handle values of zero in field visit measurements

### DIFF
--- a/R/dvhydrograph-render.R
+++ b/R/dvhydrograph-render.R
@@ -155,8 +155,6 @@ createDVHydrographPlot <- function(reportObject){
   plot_object <- plotItem(plot_object, minMaxPoints[['min_iv']], getDVHydrographPlotConfig, list(minMaxPoints[['min_iv']], 'min_iv', minMaxEst=minMaxEst[['min_iv']]), isDV=TRUE)
   plot_object <- plotItem(plot_object, minMaxPoints[['max_iv']], getDVHydrographPlotConfig, list(minMaxPoints[['max_iv']], 'max_iv', minMaxEst=minMaxEst[['max_iv']]), isDV=TRUE)
 
-  
-  
   # approval bar styles are applied last, because it makes it easier to align
   # them with the top of the x-axis line
   plot_object <- addToGsplot(plot_object, getApprovalBarConfig(approvals, ylim(plot_object, side = 2), logAxis))

--- a/R/dvhydrograph-render.R
+++ b/R/dvhydrograph-render.R
@@ -99,7 +99,7 @@ createDVHydrographPlot <- function(reportObject){
   comparisonEdgesDf <- as.data.frame(comparisonEdges, stringsAsFactors = FALSE)
   
   #remove zeros from field measurements, if present:
-  if (excludeZeroNegativeFlag && !isEmptyOrBlank(fieldVisitMeasurements)) {
+  if (logAxis) {
     fieldVisitMeasurements <- removeZeroNegative(fieldVisitMeasurements)
   }
 

--- a/R/utils-parse.r
+++ b/R/utils-parse.r
@@ -145,7 +145,8 @@ parseWaterQualityMeasurements <- function(reportObject){
 #' @description Given the full report JSON object, reads the field
 #' visit measurements and handles read errors.
 #' @param reportObject the full report JSON object
-parseFieldVisitMeasurements <- function(reportObject){
+#' @param excludeZeroNegativeFlag whether or not zero/negative values are included
+parseFieldVisitMeasurements <- function(reportObject, excludeZeroNegativeFlag){
   meas_Q <- tryCatch({
     readFieldVisitMeasurementsQPoints(reportObject)
   }, error = function(e) {
@@ -156,6 +157,18 @@ parseFieldVisitMeasurements <- function(reportObject){
   if(!anyDataExist(meas_Q) || nrow(meas_Q) == 0){
     meas_Q <- NULL
     warning("Data was retrieved for field visit measurements but it was empty. Returning NULL.")
+  }
+  
+  #Check if the field visit measurements (if they exist) allow for a log axis or not, and remove zeros/negative values if indicated
+  if (!isEmptyOrBlank(meas_Q)) {
+    if(!isEmptyOrBlank(meas_Q[['value']]) && meas_Q[['value']] <= 0 && isEmptyOrBlank(excludeZeroNegativeFlag)){
+      meas_Q[['canLog']] <- FALSE
+    } else if(!isEmptyOrBlank(meas_Q[['value']]) && meas_Q[['value']] <= 0 && !isEmptyOrBlank(excludeZeroNegativeFlag) && excludeZeroNegativeFlag ) {
+      meas_Q[['canLog']] <- TRUE
+    }
+    else if(!isEmptyOrBlank(meas_Q[['value']]) && meas_Q[['value']] > 0 ) {
+      meas_Q[['canLog']] <- TRUE
+    }
   }
   return(meas_Q)
 }

--- a/inst/extdata/testsnippets/test-dvhydrograph.json
+++ b/inst/extdata/testsnippets/test-dvhydrograph.json
@@ -82,7 +82,7 @@
             "timezone": "Etc/GMT+5",
             "isInverted": true,
             "startDate": "2013-11-10",
-            "endDate": "2014-11-12",
+            "endDate": "2014-11-16",
             "title": "DV Hydrograph",
             "stationId": "01054200",
             "stationName": "test station",
@@ -867,6 +867,237 @@
                 "toleranceInMinutes": 1440
             }
             ]
+        }
+    },
+    "fieldMeasurementZeroDischargeExclZeroNeg": {
+        "reportMetadata": {
+            "timezone": "Etc/GMT+5",
+            "isInverted": true,
+            "startDate": "2013-11-10",
+            "endDate": "2014-11-12",
+            "title": "DV Hydrograph",
+            "stationId": "01054200",
+            "stationName": "test station",
+            "firstStatDerivedLabel": "Discharge.ft^3/s.Mean@01054200",
+            "primarySeriesLabel": "Discharge.ft^3/s@01054200",
+            "excludeZeroNegative": true
+        },
+        "primarySeriesApprovals": [
+            {
+                "level": 1200,
+                "description": "Approved",
+                "comment": "",
+                "dateApplied": "2016-09-04T23:53:53.2623141Z",
+                "startTime": "1963-10-01T00:00:00-05:00",
+                "endTime": "2015-10-05T00:00:00-05:00"
+            }
+        ],
+        "maxMinData": {
+            "seriesTimeSeriesPoints": {
+                "DataRetrievalRequest-dc10355d-daf8-4aa9-8d8b-c8ab69c16f99": {
+                    "startTime": "2013-11-10T00:00:00-05:00",
+                    "endTime": "2013-12-11T23:59:59.999999999-05:00",
+                    "qualifiers": [],
+                    "theseTimeSeriesPoints": {
+                        "MAX": [
+                            {
+                                "time": "2013-11-11T12:00:00-05:00",
+                                "value": 892
+                            }
+                        ],
+                        "MIN": [
+                            {
+                                "time": "2013-11-12T22:45:00-05:00",
+                                "value": -60.5
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "fieldVisitMeasurements": [
+        {
+          "identifier": "509F9C0F15B6F99CE0530100007F12A5",
+          "measurementStartDate": "2016-10-14T14:00:00-07:00",
+          "discharge": 0.00,
+          "dischargeUnits": "ft^3/s",
+          "errorMinDischarge": 0.000000,
+          "errorMaxDischarge": 0.000000,
+          "measurementNumber": "522",
+          "qualityRating": "EXCELLENT",
+          "historic": false,
+          "meanGageHeightUnits": "ft",
+          "shiftNumber": 0
+      }],
+        "firstStatDerived": {
+            "notes": [],
+            "isVolumetricFlow": true,
+            "description": "From Aquarius",
+            "qualifiers": [
+                {
+                    "startDate": "2013-11-11T00:00:00-05:00",
+                    "endDate": "2013-11-12T00:00:00-05:00",
+                    "identifier": "ESTIMATED",
+                    "code": "E",
+                    "appliedBy": "admin",
+                    "dateApplied": "2016-09-04T19:36:45.3185938Z"
+                }
+            ],
+            "units": "ft^3/s",
+            "grades": [],
+            "type": "Discharge",
+            "gaps": [],
+            "points": [
+                {
+                    "time": "2013-11-10",
+                    "value": 66.6
+                },
+                {
+                    "time": "2013-11-11",
+                    "value": 66.5
+                },
+                {
+                    "time": "2013-11-12",
+                    "value": 66.4
+                }
+            ],
+            "requestedStartTime": "2013-11-10T00:00:00-05:00",
+            "requestedEndTime": "2013-12-11T23:59:59.999999999-05:00",
+            "estimatedPeriods": [
+                {
+                    "startDate": "2013-11-11T00:00:00-05:00",
+                    "endDate": "2013-11-12T00:00:00-05:00"
+                }
+            ],
+            "approvals": [
+                {
+                    "level": 1200,
+                    "description": "Approved",
+                    "comment": "",
+                    "dateApplied": "2016-09-04T23:53:53.2623141Z",
+                    "startTime": "1963-10-01T00:00:00-05:00",
+                    "endTime": "2015-10-05T00:00:00-05:00"
+                }
+            ],
+            "name": "24eca840ec914810a88f00a96a70fc88",
+            "startTime": "2013-11-09",
+            "endTime": "2013-12-11",
+            "gapTolerances": []
+        }
+    },
+        "fieldMeasurementZeroDischargeZeroNeg": {
+        "reportMetadata": {
+            "timezone": "Etc/GMT+5",
+            "isInverted": true,
+            "startDate": "2013-11-10",
+            "endDate": "2014-11-12",
+            "title": "DV Hydrograph",
+            "stationId": "01054200",
+            "stationName": "test station",
+            "firstStatDerivedLabel": "Discharge.ft^3/s.Mean@01054200",
+            "primarySeriesLabel": "Discharge.ft^3/s@01054200"
+        },
+        "primarySeriesApprovals": [
+            {
+                "level": 1200,
+                "description": "Approved",
+                "comment": "",
+                "dateApplied": "2016-09-04T23:53:53.2623141Z",
+                "startTime": "1963-10-01T00:00:00-05:00",
+                "endTime": "2015-10-05T00:00:00-05:00"
+            }
+        ],
+        "maxMinData": {
+            "seriesTimeSeriesPoints": {
+                "DataRetrievalRequest-dc10355d-daf8-4aa9-8d8b-c8ab69c16f99": {
+                    "startTime": "2013-11-10T00:00:00-05:00",
+                    "endTime": "2013-12-11T23:59:59.999999999-05:00",
+                    "qualifiers": [],
+                    "theseTimeSeriesPoints": {
+                        "MAX": [
+                            {
+                                "time": "2013-11-11T12:00:00-05:00",
+                                "value": 892
+                            }
+                        ],
+                        "MIN": [
+                            {
+                                "time": "2013-11-12T22:45:00-05:00",
+                                "value": -60.5
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "fieldVisitMeasurements": [
+        {
+          "identifier": "509F9C0F15B6F99CE0530100007F12A5",
+          "measurementStartDate": "2016-10-14T14:00:00-07:00",
+          "discharge": 0.00,
+          "dischargeUnits": "ft^3/s",
+          "errorMinDischarge": 0.000000,
+          "errorMaxDischarge": 0.000000,
+          "measurementNumber": "522",
+          "qualityRating": "EXCELLENT",
+          "historic": false,
+          "meanGageHeightUnits": "ft",
+          "shiftNumber": 0
+      }],
+        "firstStatDerived": {
+            "notes": [],
+            "isVolumetricFlow": true,
+            "description": "From Aquarius",
+            "qualifiers": [
+                {
+                    "startDate": "2013-11-11T00:00:00-05:00",
+                    "endDate": "2013-11-12T00:00:00-05:00",
+                    "identifier": "ESTIMATED",
+                    "code": "E",
+                    "appliedBy": "admin",
+                    "dateApplied": "2016-09-04T19:36:45.3185938Z"
+                }
+            ],
+            "units": "ft^3/s",
+            "grades": [],
+            "type": "Discharge",
+            "gaps": [],
+            "points": [
+                {
+                    "time": "2013-11-10",
+                    "value": 66.6
+                },
+                {
+                    "time": "2013-11-11",
+                    "value": 66.5
+                },
+                {
+                    "time": "2013-11-12",
+                    "value": 66.4
+                }
+            ],
+            "requestedStartTime": "2013-11-10T00:00:00-05:00",
+            "requestedEndTime": "2013-12-11T23:59:59.999999999-05:00",
+            "estimatedPeriods": [
+                {
+                    "startDate": "2013-11-11T00:00:00-05:00",
+                    "endDate": "2013-11-12T00:00:00-05:00"
+                }
+            ],
+            "approvals": [
+                {
+                    "level": 1200,
+                    "description": "Approved",
+                    "comment": "",
+                    "dateApplied": "2016-09-04T23:53:53.2623141Z",
+                    "startTime": "1963-10-01T00:00:00-05:00",
+                    "endTime": "2015-10-05T00:00:00-05:00"
+                }
+            ],
+            "name": "24eca840ec914810a88f00a96a70fc88",
+            "startTime": "2013-11-09",
+            "endTime": "2013-12-11",
+            "gapTolerances": []
         }
     }
 }

--- a/man/parseFieldVisitMeasurements.Rd
+++ b/man/parseFieldVisitMeasurements.Rd
@@ -4,10 +4,12 @@
 \alias{parseFieldVisitMeasurements}
 \title{Parse Field Visit Measurements}
 \usage{
-parseFieldVisitMeasurements(reportObject)
+parseFieldVisitMeasurements(reportObject, excludeZeroNegativeFlag)
 }
 \arguments{
 \item{reportObject}{the full report JSON object}
+
+\item{excludeZeroNegativeFlag}{whether or not zero/negative values are included}
 }
 \description{
 Given the full report JSON object, reads the field

--- a/tests/testthat/test-dvhydrograph.R
+++ b/tests/testthat/test-dvhydrograph.R
@@ -254,4 +254,14 @@ test_that("full DV Hydro report rendering functions properly", {
   expect_is(dvhydrograph(reportObject, 'author'), 'character')
 })
 
+test_that("field visits with discharge values of zero functions properly when excluding zeros and negs", {
+  reportObject <- dvHydroTestJSON[['fieldMeasurementZeroDischargeExclZeroNeg']]
+  expect_is(dvhydrograph(reportObject, 'author'), 'character')
+})
+
+test_that("field visits with discharge values of zero functions properly when not excluding zeros and negs", {
+  reportObject <- dvHydroTestJSON[['fieldMeasurementZeroDischargeZeroNeg']]
+  expect_is(dvhydrograph(reportObject, 'author'), 'character')
+})
+
 setwd(dir = wd)


### PR DESCRIPTION
Zeros in field visit measurements would break the log axis
functionality.  Fix was two-fold: added a check for zeros in field visit
measurement data when excludeZeroNegative was false or missing. Then
stripped zeros/negatives from field visit measurement data when
excludeZeroNegative was true.