### PR TITLE
AQCU-1212 don't force gaps to noon + print zero times + tests

### DIFF
--- a/R/utils-read.R
+++ b/R/utils-read.R
@@ -910,8 +910,13 @@ readGaps <- function(reportObject, timezone){
   
   if(validateFetchedData(gaps, 'Gaps', requiredFields, stopEmpty=FALSE)){
     returnList <- gaps
-    returnList[['startTime']] <- flexibleTimeParse(returnList[['startTime']], timezone)
-    returnList[['endTime']] <- flexibleTimeParse(returnList[['endTime']], timezone)
+    returnList[['startTime']] <- flexibleTimeParse(returnList[['startTime']], timezone,
+                                                   shiftTimeToNoon = FALSE)
+    returnList[['startTime']] <- as.repgendate(returnList[['startTime']])
+    
+    returnList[['endTime']] <- flexibleTimeParse(returnList[['endTime']], timezone,
+                                                 shiftTimeToNoon = FALSE)
+    returnList[['endTime']] <- as.repgendate(returnList[['endTime']])
   }
   
   return(returnList)

--- a/tests/testthat/test-utils-parse.R
+++ b/tests/testthat/test-utils-parse.R
@@ -446,8 +446,8 @@ test_that('parseGaps properly retrieves and formats the gaps', {
   expect_equal(nullGaps, NULL)
   expect_is(gaps, 'data.frame')
   expect_equal(nrow(gaps), 2)
-  expect_equal(gaps[['startTime']][[1]], flexibleTimeParse('2016-11-23T00:00:00-05:00', timezone))
-  expect_equal(gaps[['endTime']][[1]], flexibleTimeParse("2016-11-23T12:00:00-05:00", timezone))
+  expect_equal(gaps[['startTime']][[1]], as.repgendate(flexibleTimeParse('2016-11-23T00:00:00-05:00', timezone)))
+  expect_equal(gaps[['endTime']][[1]], as.repgendate(flexibleTimeParse("2016-11-23T12:00:00-05:00", timezone)))
 })
 
 test_that("parseThresholds properly retrieves the threshold data", {

--- a/tests/testthat/test-utils-read.R
+++ b/tests/testthat/test-utils-read.R
@@ -1739,8 +1739,39 @@ test_that('readGaps properly retrieves and formats the gaps', {
   
   expect_is(gaps, 'data.frame')
   expect_equal(nrow(gaps), 2)
-  expect_equal(gaps[['startTime']][[1]], flexibleTimeParse('2016-11-23T00:00:00-05:00', timezone))
-  expect_equal(gaps[['endTime']][[1]], flexibleTimeParse("2016-11-23T12:00:00-05:00", timezone))
+  expect_equal(gaps[['startTime']][[1]], as.repgendate(flexibleTimeParse('2016-11-23T00:00:00-05:00', timezone)))
+  expect_equal(gaps[['endTime']][[1]], as.repgendate(flexibleTimeParse("2016-11-23T12:00:00-05:00", timezone)))
+})
+
+test_that('readGaps properly retrieves and formats DV gaps', {
+  timezone <- "Etc/GMT+5"
+  gapJson <- fromJSON('{
+    "primaryTsData":{
+      "gaps": [
+        {
+          "startTime": "2016-12-17",
+          "endTime": "2016-12-20",
+          "durationInHours": 72.0,
+          "gapExtent": "CONTAINED"
+        },
+        {
+          "startTime": "2016-12-22",
+          "endTime": "2016-12-28",
+          "durationInHours": 144.0,
+          "gapExtent": "CONTAINED"
+        }
+      ]
+    }
+}')
+  
+  gaps <- repgen:::readGaps(gapJson, timezone)
+  
+  expect_is(gaps, 'data.frame')
+  expect_equal(nrow(gaps), 2)
+  expect_equal(gaps[['startTime']][[1]], as.repgendate(as.POSIXct('2016-12-17', tz=timezone)))
+  expect_equal(gaps[['endTime']][[1]], as.repgendate(as.POSIXct('2016-12-20', tz=timezone)))
+  expect_true('repgendate' %in% class(gaps[['startTime']]))
+  expect_true('repgendate' %in% class(gaps[['endTime']]))
 })
 
 test_that('readUpchainSeries properly retrieves the related upchain series', {


### PR DESCRIPTION
DV Gaps in TSS were printing as "2010-10-01 12:00:00", and should now be printing as "2010-10-01 00:00:00".