### PR TITLE
AQCU-1212 DV gaps w/ no time + note in report + update as.repgendate

### DIFF
--- a/R/utils-read.R
+++ b/R/utils-read.R
@@ -912,11 +912,8 @@ readGaps <- function(reportObject, timezone){
     returnList <- gaps
     returnList[['startTime']] <- flexibleTimeParse(returnList[['startTime']], timezone,
                                                    shiftTimeToNoon = FALSE)
-    returnList[['startTime']] <- as.repgendate(returnList[['startTime']])
-    
     returnList[['endTime']] <- flexibleTimeParse(returnList[['endTime']], timezone,
                                                  shiftTimeToNoon = FALSE)
-    returnList[['endTime']] <- as.repgendate(returnList[['endTime']])
   }
   
   return(returnList)

--- a/R/utils-time.R
+++ b/R/utils-time.R
@@ -205,7 +205,9 @@ formatOpenDateLabel <- function(dates){
 #' @param x a date vector
 #' @export
 as.repgendate <- function(x){
-  class(x) <- c("repgendate", class(x))
+  if(!is.repgendate(x)){
+    class(x) <- c("repgendate", class(x))
+  }
   return(x)
 }
 

--- a/inst/templates/timeseriessummary/body.mustache
+++ b/inst/templates/timeseriessummary/body.mustache
@@ -134,6 +134,8 @@
           </table>
           <br/>
           <br/>
+          <span>Gap dates are exclusive, therefore the gap period is inside the listed dates.</span>
+          <br/>
           <span>If the start or end of the report period is during a gap, then the gap will not be listed in the table below.</span>
           <h3>Gaps in Time Series</h3>
           <table id="table-gaps" class="table sortable-theme-slick" data-sortable>

--- a/tests/testthat/test-utils-read.R
+++ b/tests/testthat/test-utils-read.R
@@ -1739,8 +1739,10 @@ test_that('readGaps properly retrieves and formats the gaps', {
   
   expect_is(gaps, 'data.frame')
   expect_equal(nrow(gaps), 2)
-  expect_equal(gaps[['startTime']][[1]], as.repgendate(flexibleTimeParse('2016-11-23T00:00:00-05:00', timezone)))
-  expect_equal(gaps[['endTime']][[1]], as.repgendate(flexibleTimeParse("2016-11-23T12:00:00-05:00", timezone)))
+  expect_equal(gaps[['startTime']][[1]], flexibleTimeParse('2016-11-23T00:00:00-05:00', timezone))
+  expect_equal(gaps[['endTime']][[1]], flexibleTimeParse("2016-11-23T12:00:00-05:00", timezone))
+  expect_true('repgendate' %in% class(gaps[['startTime']]))
+  expect_true('repgendate' %in% class(gaps[['endTime']]))
 })
 
 test_that('readGaps properly retrieves and formats DV gaps', {
@@ -1762,16 +1764,17 @@ test_that('readGaps properly retrieves and formats DV gaps', {
         }
       ]
     }
-}')
+  }')
   
   gaps <- repgen:::readGaps(gapJson, timezone)
   
   expect_is(gaps, 'data.frame')
   expect_equal(nrow(gaps), 2)
-  expect_equal(gaps[['startTime']][[1]], as.repgendate(as.POSIXct('2016-12-17', tz=timezone)))
-  expect_equal(gaps[['endTime']][[1]], as.repgendate(as.POSIXct('2016-12-20', tz=timezone)))
-  expect_true('repgendate' %in% class(gaps[['startTime']]))
-  expect_true('repgendate' %in% class(gaps[['endTime']]))
+  # should show up as DVs, not with 00:00 for time
+  expect_equal(gaps[['startTime']][[1]], as.POSIXct('2016-12-17', tz=timezone))
+  expect_equal(gaps[['endTime']][[1]], as.POSIXct('2016-12-20', tz=timezone))
+  expect_false('repgendate' %in% class(gaps[['startTime']]))
+  expect_false('repgendate' %in% class(gaps[['endTime']]))
 })
 
 test_that('readUpchainSeries properly retrieves the related upchain series', {

--- a/tests/testthat/test-utils-time.R
+++ b/tests/testthat/test-utils-time.R
@@ -190,11 +190,19 @@ test_that("as.repgendate adds a new class and retains originals", {
   expect_true("repgendate" %in% class(y2))
   expect_true("numeric" %in% class(y2))
   
+
+  
+})
+
+test_that("as.repgendate does not affect object that already has this class", {
+  
   z1 <- as.POSIXct("2010-10-01 11:30")
   z2 <- as.repgendate(z1)
+  z3 <- as.repgendate(z2)
   expect_false("repgendate" %in% class(z1))
   expect_true("repgendate" %in% class(z2))
   expect_true(all(class(z1) %in% class(z2)))
+  expect_equal(length(grep("repgendate", class(z3))), 1)
   
 })
 


### PR DESCRIPTION
Daily value time series gaps are not coerced to noon (that was for plotting purposes). Note added to report about the gaps being exclusive: “Gap dates are exclusive, therefore the gap period is inside the listed dates.”

Also, bug in `as.repgendate` found and fixed - it was adding "repgendate" as a class even when the object already had that class. So the result was a duplicated class.
