### PR TITLE
Testing newer version of crayon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
 install:
 
   #Install First Set of Dependencies
+  - Rscript -e 'install.packages("crayon")'
   - Rscript -e 'install.packages(c("bitops","Rcpp","digest","magrittr","stringi","stringr","yaml","evaluate","formatr","highr","R6","assertthat","lazyeval","DBI","jsonlite","brew","mime","curl","caTools","openssl","memoise","whisker","rstudioapi","git2r","withr","markdown","knitr","htmltools", "rmarkdown","RCurl","htmlTable","roxygen2","dplyr","lubridate", "readr", "base64enc", "whisker"), repos="https://mran.microsoft.com/snapshot/2017-02-08", type="source")'
   
   #Install a different version of HTTR


### PR DESCRIPTION
travis is failing on testthat install, trying to install crayon first so it's more up to date than mran version