### PR TITLE
AQCU-1592: expand the limits to include estimated comparison data

### DIFF
--- a/R/uvhydrograph-render.R
+++ b/R/uvhydrograph-render.R
@@ -503,7 +503,8 @@ sortDataAndSides <- function(primarySeriesList, uvInfo, refInfo, compInfo) {
                              primarySeriesList[['estimated']][['points']])
   
   ylimReferenceData <- primarySeriesList[['corrected_reference']][['points']]
-  ylimCompData <- primarySeriesList[['comparison']][['points']]
+  ylimCompData <- rbind(primarySeriesList[['comparison']][['points']],
+                        primarySeriesList[['estimated_comparison']][['points']])
   
   primarySide <- 2
   referenceSide <- 4


### PR DESCRIPTION
When adding the estimated comparison data to display on the graph I just had it use the existing comparison limits, now it includes the estimated comparison limits in as well.