### PR TITLE
AQCU-1352: missing qualifiers

### DIFF
--- a/R/extremes-data.R
+++ b/R/extremes-data.R
@@ -392,7 +392,7 @@ applyQualifiersToValues <- function(points, qualifiers) {
         
         if (10 < nchar(p$time)) {
           # if date(time) point intersects (the open-open) interval
-          if (startDate < p$time & p$time < endDate) {
+          if (startDate <= p$time & p$time <= endDate) {
             builtQualifiers <- paste0(builtQualifiers, q$code, ",")
           }
         } else {


### PR DESCRIPTION
include qualifiers on dates that are exactly matching the start/end times for the period