### PR TITLE
Aqcu 1351 legacy branch extremes fix for strsplit error

### DIFF
--- a/R/extremes-data.R
+++ b/R/extremes-data.R
@@ -137,7 +137,7 @@ getExtremesTableQualifiers <- function(table, primaryHeaderTerm, upchainHeaderTe
   toRet <- list()
 
   #Extract Necessary Data Columns
-  relevantData <- strsplit(unlist(as.character(table[grepl(paste0(primaryHeaderTerm, "|", upchainHeaderTerm), names(table))])), " ")
+  relevantData <- strsplit(unlist(table[grepl(paste0(primaryHeaderTerm, "|", upchainHeaderTerm), names(table))]), " ")
   
   for(i in 1:length(relevantData)){
     if(length(relevantData[[i]]) > 1){
@@ -432,6 +432,8 @@ applyQualifiersToValues <- function(points, qualifiers) {
     pointsWithQs$quals <- NULL
     points <- pointsWithQs
   }
+  
+  points$value <- as.character(points$value)
   
   return(points)
 }

--- a/R/extremes-data.R
+++ b/R/extremes-data.R
@@ -137,7 +137,7 @@ getExtremesTableQualifiers <- function(table, primaryHeaderTerm, upchainHeaderTe
   toRet <- list()
 
   #Extract Necessary Data Columns
-  relevantData <- strsplit(unlist(table[grepl(paste0(primaryHeaderTerm, "|", upchainHeaderTerm), names(table))]), " ")
+  relevantData <- strsplit(unlist(as.character(table[grepl(paste0(primaryHeaderTerm, "|", upchainHeaderTerm), names(table))])), " ")
   
   for(i in 1:length(relevantData)){
     if(length(relevantData[[i]]) > 1){
@@ -432,6 +432,7 @@ applyQualifiersToValues <- function(points, qualifiers) {
     pointsWithQs$quals <- NULL
     points <- pointsWithQs
   }
+  
   return(points)
 }
 

--- a/tests/testthat/test-extremes.R
+++ b/tests/testthat/test-extremes.R
@@ -552,13 +552,13 @@ test_that("extremes report qualifiers are associated correctly (applyQualifiers)
   
   qualifiersApplied <- repgen:::applyQualifiers(reportObject)
   expect_equal(qualifiersApplied$upchain$min$relatedPrimary[1,]$value, "I, E 659")
-  expect_equal(qualifiersApplied$upchain$min$points[1,]$value, 1.62) #not in qualifier range
+  expect_equal(qualifiersApplied$upchain$min$points[1,]$value, "1.62") #not in qualifier range
   expect_equal(qualifiersApplied$upchain$max$relatedPrimary[1,]$value, "I, E 56900")
-  expect_equal(qualifiersApplied$upchain$max$points[1,]$value, 21.75) #not in qualifier range
+  expect_equal(qualifiersApplied$upchain$max$points[1,]$value, "21.75") #not in qualifier range
   
-  expect_equal(qualifiersApplied$primary$min$relatedUpchain[1,]$value, 1.62) #not in qualifier range
+  expect_equal(qualifiersApplied$primary$min$relatedUpchain[1,]$value, "1.62") #not in qualifier range
   expect_equal(qualifiersApplied$primary$min$points[1,]$value, "I, E 659") 
-  expect_equal(qualifiersApplied$primary$max$relatedUpchain[1,]$value, 21.75) #not in qualifier range
+  expect_equal(qualifiersApplied$primary$max$relatedUpchain[1,]$value, "21.75") #not in qualifier range
   expect_equal(qualifiersApplied$primary$max$points[1,]$value, "I, E 56900")
 })
 


### PR DESCRIPTION
- removing the dplyr:mutate from the applyQualifiers function caused these data to come back from that function as a mix of characters and integers/numbers. this caused an error further in the report functions.