### PR TITLE
AQCU-1689: overzealous fix when addressing accidental erasing of existing qualifiers

### DIFF
--- a/R/extremes-data.R
+++ b/R/extremes-data.R
@@ -108,6 +108,7 @@ extremesQualifiersTable <- function(reportObject, table, primaryHeaderTerm, upch
   #Construct List of all qualifiers
   qualifiersList <- list(data.frame(reportObject$dv$qualifiers), data.frame(reportObject$upchain$qualifiers), data.frame(reportObject$primary$qualifiers))
   qualifiersList <- Reduce(function(...) merge(..., all=T), qualifiersList)
+  
   columnNames <- c("Code",
                   "Identifier",
                   "Description"
@@ -395,7 +396,7 @@ applyQualifiersToValues <- function(points, qualifiers) {
           }
           # if it doesn't intersect, check to see if it has a previous qualifier or not, and if not, paste nothing, but if so, paste what was there before
           else { 
-            pointQs$quals[j] <- ifelse(isEmptyOrBlank(pointQs$quals[j]), paste0(""), paste0(pointQs$quals[j], qualifiers$code[i], ","))
+            pointQs$quals[j] <- ifelse(isEmptyOrBlank(pointQs$quals[j]), paste0(""), paste0(pointQs$quals[j]))
             pointQs$time[j] <- points$time[j]
           }
         } else {
@@ -406,7 +407,7 @@ applyQualifiersToValues <- function(points, qualifiers) {
           }
           # if it doesn't intersect, check to see if it has a previous qualifier or not, and if not, paste nothing, but if so, paste what was there before
           else {
-            pointQs$quals[j] <- ifelse(isEmptyOrBlank(pointQs$quals[j]), paste0(""), paste0(pointQs$quals[j], qualifiers$code[i], ","))
+            pointQs$quals[j] <- ifelse(isEmptyOrBlank(pointQs$quals[j]), paste0(""), paste0(pointQs$quals[j]))
             pointQs$time[j] <- points$time[j]
           }
         }

--- a/R/extremes-data.R
+++ b/R/extremes-data.R
@@ -108,7 +108,6 @@ extremesQualifiersTable <- function(reportObject, table, primaryHeaderTerm, upch
   #Construct List of all qualifiers
   qualifiersList <- list(data.frame(reportObject$dv$qualifiers), data.frame(reportObject$upchain$qualifiers), data.frame(reportObject$primary$qualifiers))
   qualifiersList <- Reduce(function(...) merge(..., all=T), qualifiersList)
-  
   columnNames <- c("Code",
                   "Identifier",
                   "Description"


### PR DESCRIPTION
and then adding the qualifier that shouldn't have been there. Ironed out so that if the qualifier isn't applicable, it just keeps what is currently there, and if nothing is currently there in qualifiers, it just adds nothing to the existing list of applied qualifiers.