### PR TITLE
AQCU-1678: rename conditionaldata mapping

### DIFF
--- a/inst/templates/derivationchain/custom.js
+++ b/inst/templates/derivationchain/custom.js
@@ -33,7 +33,7 @@ var processorMap = {
 		"calculation" : 'calculation',
 		"correctedpassthrough" : "correctedpassthrough",
 		"fillmissingdata": "fillmissingdata",
-		"conditionalfill": "conditionaldata",
+		"conditionaldata": "conditionaldata",
 		"datumconversion": "datumconversion",
 		"transformation": "transformation",
 		"noprocessor": "noprocessor"


### PR DESCRIPTION
prior to this change, caused conditionalFill processor entries in the DC plot to be empty and the legend said 'undefined'